### PR TITLE
Add ServersTransport option to service config

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -505,6 +505,11 @@ func applyServiceOptions(lb *dynamic.ServersLoadBalancer, service internal.Servi
 			FlushInterval: flushInterval,
 		}
 	}
+	
+	// Handle ServerTransport
+	if serverTransport, exists := service.Config[prefix+".serverstransport"]; exists {
+		lb.ServersTransport = serverTransport
+	}
 }
 
 // Handle TLS configuration


### PR DESCRIPTION
The applyServiceOptions function now sets the ServersTransport field on the ServersLoadBalancer if the corresponding config key is present. This allows specifying a custom transport for service servers.

---

Previously having a label like `traefik.http.services.homeassistant.loadbalancer.serverstransport=sslskipverify-transport@file` was ignored - with this PR that is no longer the case