### PR TITLE
Log spam fix (partially)

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -200,7 +200,7 @@ func TestProviderParserConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := newParserConfig(tt.apiEndpoint, tt.tokenID, tt.token)
+			config, err := newParserConfig(tt.apiEndpoint, tt.tokenID, tt.token, "debug", true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newParserConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This fixes some of the log spam (#15). 

I'm not a go developer, but the code is simple and should work. I could test it, but I have no idea how to install the plugin locally.

I followed the instructions at https://plugins.traefik.io/install
 
- `mkdir -p /etc/traefik/plugins-local/github.com/NX211`
- `cd /etc/traefik/plugins-local/github.com/NX211`
- `git clone <my fork>`
- restart traefik
 but it didn't work.
