### PR TITLE
feat: add middleware creation support from Proxmox VM/LXC labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Traefik Proxmox Provider
+
+A Traefik plugin that uses a Proxmox VE cluster as a provider for dynamic configuration.
+
+## Project Structure
+
+- `provider/provider.go` — Main plugin logic: polling, service scanning, Traefik dynamic config generation
+- `provider/middleware.go` — Middleware builder functions for all 23 Traefik HTTP middleware types
+- `provider/middleware_test.go` — Tests for middleware builders and integration
+- `internal/client.go` — Proxmox API HTTP client
+- `internal/models.go` — Data types (Service, ParsedConfig, IP, etc.)
+
+## Branches
+
+- **`main`** — Stable base, uses `log.Printf` for logging, Go 1.19
+- **`feat/middleware-support`** — Middleware creation support, branched from `main`, uses `log.Printf`
+- **`feat/slog-structured-logging`** — Migrated logging to `log/slog`, also has middleware support with slog logging
+
+## Key Constraints
+
+- **Yaegi runtime**: This plugin runs inside Traefik's Yaegi Go interpreter. Only standard library packages are available — no third-party logging libraries (zerolog, logrus, zap).
+- **No `unsafe` package**: Traefik disables `unsafe` for plugins. This doesn't affect stdlib packages (loaded pre-compiled), but blocks third-party libs that import `unsafe`.
+- **Logging**: `main` and `feat/middleware-support` use `log.Printf`. `feat/slog-structured-logging` uses `log/slog` (requires Go 1.21+).
+
+## Middleware Support
+
+Middlewares are defined via Proxmox VM description labels:
+```
+traefik.http.middlewares.<name>.<type>.<field>=<value>
+```
+
+The `generateConfiguration()` function scans for `traefik.http.middlewares.*` prefixes, extracts middleware name and type, then dispatches to type-specific builder functions in `middleware.go`.
+
+Supported types: AddPrefix, StripPrefix, StripPrefixRegex, ReplacePath, ReplacePathRegex, RedirectRegex, RedirectScheme, Chain, BasicAuth, DigestAuth, ForwardAuth, Headers, IPAllowList, IPWhiteList, RateLimit, InFlightReq, Buffering, CircuitBreaker, Compress, ContentType, Errors, PassTLSClientCert, Retry.
+
+## Build & Test
+
+```bash
+make test        # Run unit tests
+make lint        # Run golangci-lint
+make yaegi_test  # Verify Yaegi interpreter compatibility
+make vendor      # Update vendored dependencies
+```
+
+Note: `make test` exits with code 2 due to missing `covdata` tool — all tests still pass. Check `go test -v ./...` output for actual results.

--- a/provider/middleware.go
+++ b/provider/middleware.go
@@ -1,0 +1,632 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/traefik/genconf/dynamic"
+	"github.com/traefik/genconf/dynamic/types"
+)
+
+// getLabelsByPrefix returns all labels matching the given prefix with the prefix stripped.
+func getLabelsByPrefix(config map[string]string, prefix string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range config {
+		if strings.HasPrefix(k, prefix) {
+			result[strings.TrimPrefix(k, prefix)] = v
+		}
+	}
+	return result
+}
+
+// splitCommaSeparated splits a comma-separated string and trims whitespace from each element.
+func splitCommaSeparated(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// stringToInt64 converts a string to int64.
+func stringToInt64(s string) (int64, error) {
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// buildMiddleware dispatches to type-specific builders based on the middleware type name.
+func buildMiddleware(mwType string, allLabels map[string]string, mwName string) (*dynamic.Middleware, error) {
+	prefix := fmt.Sprintf("traefik.http.middlewares.%s.%s.", mwName, mwType)
+	fields := getLabelsByPrefix(allLabels, prefix)
+
+	switch strings.ToLower(mwType) {
+	case "addprefix":
+		return buildAddPrefix(fields)
+	case "stripprefix":
+		return buildStripPrefix(fields)
+	case "stripprefixregex":
+		return buildStripPrefixRegex(fields)
+	case "replacepath":
+		return buildReplacePath(fields)
+	case "replacepathregex":
+		return buildReplacePathRegex(fields)
+	case "redirectregex":
+		return buildRedirectRegex(fields)
+	case "redirectscheme":
+		return buildRedirectScheme(fields)
+	case "chain":
+		return buildChain(fields)
+	case "basicauth":
+		return buildBasicAuth(fields)
+	case "digestauth":
+		return buildDigestAuth(fields)
+	case "forwardauth":
+		return buildForwardAuth(fields)
+	case "headers":
+		return buildHeaders(fields)
+	case "ipallowlist":
+		return buildIPAllowList(fields)
+	case "ipwhitelist":
+		return buildIPWhiteList(fields)
+	case "ratelimit":
+		return buildRateLimit(fields)
+	case "inflightreq":
+		return buildInFlightReq(fields)
+	case "buffering":
+		return buildBuffering(fields)
+	case "circuitbreaker":
+		return buildCircuitBreaker(fields)
+	case "compress":
+		return buildCompress(fields)
+	case "contenttype":
+		return buildContentType(fields)
+	case "errors":
+		return buildErrorPage(fields)
+	case "passtlsclientcert":
+		return buildPassTLSClientCert(fields)
+	case "retry":
+		return buildRetry(fields)
+	default:
+		return nil, fmt.Errorf("unknown middleware type: %s", mwType)
+	}
+}
+
+func buildAddPrefix(fields map[string]string) (*dynamic.Middleware, error) {
+	return &dynamic.Middleware{
+		AddPrefix: &dynamic.AddPrefix{
+			Prefix: fields["prefix"],
+		},
+	}, nil
+}
+
+func buildStripPrefix(fields map[string]string) (*dynamic.Middleware, error) {
+	sp := &dynamic.StripPrefix{}
+	if v, ok := fields["prefixes"]; ok {
+		sp.Prefixes = splitCommaSeparated(v)
+	}
+	if v, ok := fields["forceslash"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			sp.ForceSlash = b
+		}
+	}
+	return &dynamic.Middleware{StripPrefix: sp}, nil
+}
+
+func buildStripPrefixRegex(fields map[string]string) (*dynamic.Middleware, error) {
+	spr := &dynamic.StripPrefixRegex{}
+	if v, ok := fields["regex"]; ok {
+		spr.Regex = splitCommaSeparated(v)
+	}
+	return &dynamic.Middleware{StripPrefixRegex: spr}, nil
+}
+
+func buildReplacePath(fields map[string]string) (*dynamic.Middleware, error) {
+	return &dynamic.Middleware{
+		ReplacePath: &dynamic.ReplacePath{
+			Path: fields["path"],
+		},
+	}, nil
+}
+
+func buildReplacePathRegex(fields map[string]string) (*dynamic.Middleware, error) {
+	return &dynamic.Middleware{
+		ReplacePathRegex: &dynamic.ReplacePathRegex{
+			Regex:       fields["regex"],
+			Replacement: fields["replacement"],
+		},
+	}, nil
+}
+
+func buildRedirectRegex(fields map[string]string) (*dynamic.Middleware, error) {
+	rr := &dynamic.RedirectRegex{
+		Regex:       fields["regex"],
+		Replacement: fields["replacement"],
+	}
+	if v, ok := fields["permanent"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			rr.Permanent = b
+		}
+	}
+	return &dynamic.Middleware{RedirectRegex: rr}, nil
+}
+
+func buildRedirectScheme(fields map[string]string) (*dynamic.Middleware, error) {
+	rs := &dynamic.RedirectScheme{
+		Scheme: fields["scheme"],
+		Port:   fields["port"],
+	}
+	if v, ok := fields["permanent"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			rs.Permanent = b
+		}
+	}
+	return &dynamic.Middleware{RedirectScheme: rs}, nil
+}
+
+func buildChain(fields map[string]string) (*dynamic.Middleware, error) {
+	c := &dynamic.Chain{}
+	if v, ok := fields["middlewares"]; ok {
+		c.Middlewares = splitCommaSeparated(v)
+	}
+	return &dynamic.Middleware{Chain: c}, nil
+}
+
+func buildBasicAuth(fields map[string]string) (*dynamic.Middleware, error) {
+	ba := &dynamic.BasicAuth{
+		UsersFile:   fields["usersfile"],
+		Realm:       fields["realm"],
+		HeaderField: fields["headerfield"],
+	}
+	if v, ok := fields["users"]; ok {
+		ba.Users = splitCommaSeparated(v)
+	}
+	if v, ok := fields["removeheader"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			ba.RemoveHeader = b
+		}
+	}
+	return &dynamic.Middleware{BasicAuth: ba}, nil
+}
+
+func buildDigestAuth(fields map[string]string) (*dynamic.Middleware, error) {
+	da := &dynamic.DigestAuth{
+		UsersFile:   fields["usersfile"],
+		Realm:       fields["realm"],
+		HeaderField: fields["headerfield"],
+	}
+	if v, ok := fields["users"]; ok {
+		da.Users = splitCommaSeparated(v)
+	}
+	if v, ok := fields["removeheader"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			da.RemoveHeader = b
+		}
+	}
+	return &dynamic.Middleware{DigestAuth: da}, nil
+}
+
+func buildForwardAuth(fields map[string]string) (*dynamic.Middleware, error) {
+	fa := &dynamic.ForwardAuth{
+		Address:                  fields["address"],
+		AuthResponseHeadersRegex: fields["authresponseheadersregex"],
+	}
+	if v, ok := fields["trustforwardheader"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			fa.TrustForwardHeader = b
+		}
+	}
+	if v, ok := fields["authresponseheaders"]; ok {
+		fa.AuthResponseHeaders = splitCommaSeparated(v)
+	}
+	if v, ok := fields["authrequestheaders"]; ok {
+		fa.AuthRequestHeaders = splitCommaSeparated(v)
+	}
+	tls := buildClientTLS(fields)
+	if tls != nil {
+		fa.TLS = tls
+	}
+	return &dynamic.Middleware{ForwardAuth: fa}, nil
+}
+
+func buildClientTLS(fields map[string]string) *types.ClientTLS {
+	ca := fields["tls.ca"]
+	cert := fields["tls.cert"]
+	key := fields["tls.key"]
+	insecureSkipVerify := fields["tls.insecureskipverify"]
+
+	if ca == "" && cert == "" && key == "" && insecureSkipVerify == "" {
+		return nil
+	}
+
+	t := &types.ClientTLS{
+		CA:   ca,
+		Cert: cert,
+		Key:  key,
+	}
+	if insecureSkipVerify != "" {
+		if b, err := stringToBool(insecureSkipVerify); err == nil {
+			t.InsecureSkipVerify = b
+		}
+	}
+	return t
+}
+
+func buildIPStrategy(fields map[string]string, prefix string) *dynamic.IPStrategy {
+	depthStr := fields[prefix+"ipstrategy.depth"]
+	excludedIPs := fields[prefix+"ipstrategy.excludedips"]
+
+	if depthStr == "" && excludedIPs == "" {
+		return nil
+	}
+
+	ips := &dynamic.IPStrategy{}
+	if depthStr != "" {
+		if d, err := stringToInt(depthStr); err == nil {
+			ips.Depth = d
+		}
+	}
+	if excludedIPs != "" {
+		ips.ExcludedIPs = splitCommaSeparated(excludedIPs)
+	}
+	return ips
+}
+
+func buildSourceCriterion(fields map[string]string, prefix string) *dynamic.SourceCriterion {
+	reqHeaderName := fields[prefix+"sourcecriterion.requestheadername"]
+	reqHost := fields[prefix+"sourcecriterion.requesthost"]
+	ipStrategy := buildIPStrategy(fields, prefix+"sourcecriterion.")
+
+	if reqHeaderName == "" && reqHost == "" && ipStrategy == nil {
+		return nil
+	}
+
+	sc := &dynamic.SourceCriterion{
+		RequestHeaderName: reqHeaderName,
+		IPStrategy:        ipStrategy,
+	}
+	if reqHost != "" {
+		if b, err := stringToBool(reqHost); err == nil {
+			sc.RequestHost = b
+		}
+	}
+	return sc
+}
+
+func buildIPAllowList(fields map[string]string) (*dynamic.Middleware, error) {
+	al := &dynamic.IPAllowList{}
+	if v, ok := fields["sourcerange"]; ok {
+		al.SourceRange = splitCommaSeparated(v)
+	}
+	al.IPStrategy = buildIPStrategy(fields, "")
+	return &dynamic.Middleware{IPAllowList: al}, nil
+}
+
+func buildIPWhiteList(fields map[string]string) (*dynamic.Middleware, error) {
+	wl := &dynamic.IPWhiteList{}
+	if v, ok := fields["sourcerange"]; ok {
+		wl.SourceRange = splitCommaSeparated(v)
+	}
+	wl.IPStrategy = buildIPStrategy(fields, "")
+	return &dynamic.Middleware{IPWhiteList: wl}, nil
+}
+
+func buildRateLimit(fields map[string]string) (*dynamic.Middleware, error) {
+	rl := &dynamic.RateLimit{
+		Period: fields["period"],
+	}
+	if v, ok := fields["average"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			rl.Average = n
+		}
+	}
+	if v, ok := fields["burst"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			rl.Burst = n
+		}
+	}
+	rl.SourceCriterion = buildSourceCriterion(fields, "")
+	return &dynamic.Middleware{RateLimit: rl}, nil
+}
+
+func buildInFlightReq(fields map[string]string) (*dynamic.Middleware, error) {
+	ifr := &dynamic.InFlightReq{}
+	if v, ok := fields["amount"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			ifr.Amount = n
+		}
+	}
+	ifr.SourceCriterion = buildSourceCriterion(fields, "")
+	return &dynamic.Middleware{InFlightReq: ifr}, nil
+}
+
+func buildBuffering(fields map[string]string) (*dynamic.Middleware, error) {
+	b := &dynamic.Buffering{
+		RetryExpression: fields["retryexpression"],
+	}
+	if v, ok := fields["maxrequestbodybytes"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			b.MaxRequestBodyBytes = n
+		}
+	}
+	if v, ok := fields["memrequestbodybytes"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			b.MemRequestBodyBytes = n
+		}
+	}
+	if v, ok := fields["maxresponsebodybytes"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			b.MaxResponseBodyBytes = n
+		}
+	}
+	if v, ok := fields["memresponsebodybytes"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			b.MemResponseBodyBytes = n
+		}
+	}
+	return &dynamic.Middleware{Buffering: b}, nil
+}
+
+func buildCircuitBreaker(fields map[string]string) (*dynamic.Middleware, error) {
+	return &dynamic.Middleware{
+		CircuitBreaker: &dynamic.CircuitBreaker{
+			Expression:       fields["expression"],
+			CheckPeriod:      fields["checkperiod"],
+			FallbackDuration: fields["fallbackduration"],
+			RecoveryDuration: fields["recoveryduration"],
+		},
+	}, nil
+}
+
+func buildCompress(fields map[string]string) (*dynamic.Middleware, error) {
+	c := &dynamic.Compress{}
+	if v, ok := fields["excludedcontenttypes"]; ok {
+		c.ExcludedContentTypes = splitCommaSeparated(v)
+	}
+	if v, ok := fields["minresponsebodybytes"]; ok {
+		if n, err := stringToInt(v); err == nil {
+			c.MinResponseBodyBytes = n
+		}
+	}
+	return &dynamic.Middleware{Compress: c}, nil
+}
+
+func buildContentType(fields map[string]string) (*dynamic.Middleware, error) {
+	ct := &dynamic.ContentType{}
+	if v, ok := fields["autodetect"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			ct.AutoDetect = b
+		}
+	}
+	return &dynamic.Middleware{ContentType: ct}, nil
+}
+
+func buildErrorPage(fields map[string]string) (*dynamic.Middleware, error) {
+	ep := &dynamic.ErrorPage{
+		Service: fields["service"],
+		Query:   fields["query"],
+	}
+	if v, ok := fields["status"]; ok {
+		ep.Status = splitCommaSeparated(v)
+	}
+	return &dynamic.Middleware{Errors: ep}, nil
+}
+
+func buildPassTLSClientCert(fields map[string]string) (*dynamic.Middleware, error) {
+	p := &dynamic.PassTLSClientCert{}
+	if v, ok := fields["pem"]; ok {
+		if b, err := stringToBool(v); err == nil {
+			p.PEM = b
+		}
+	}
+	info := buildTLSClientCertInfo(fields)
+	if info != nil {
+		p.Info = info
+	}
+	return &dynamic.Middleware{PassTLSClientCert: p}, nil
+}
+
+func buildTLSClientCertInfo(fields map[string]string) *dynamic.TLSClientCertificateInfo {
+	info := &dynamic.TLSClientCertificateInfo{}
+	hasField := false
+
+	boolFields := map[string]*bool{
+		"info.notafter":     &info.NotAfter,
+		"info.notbefore":    &info.NotBefore,
+		"info.sans":         &info.Sans,
+		"info.serialnumber": &info.SerialNumber,
+	}
+	for key, target := range boolFields {
+		if v, ok := fields[key]; ok {
+			if b, err := stringToBool(v); err == nil {
+				*target = b
+				hasField = true
+			}
+		}
+	}
+
+	subject := buildTLSSubjectDN(fields)
+	if subject != nil {
+		info.Subject = subject
+		hasField = true
+	}
+
+	issuer := buildTLSIssuerDN(fields)
+	if issuer != nil {
+		info.Issuer = issuer
+		hasField = true
+	}
+
+	if !hasField {
+		return nil
+	}
+	return info
+}
+
+func buildTLSSubjectDN(fields map[string]string) *dynamic.TLSClientCertificateSubjectDNInfo {
+	s := &dynamic.TLSClientCertificateSubjectDNInfo{}
+	hasField := false
+
+	boolFields := map[string]*bool{
+		"info.subject.country":            &s.Country,
+		"info.subject.province":           &s.Province,
+		"info.subject.locality":           &s.Locality,
+		"info.subject.organization":       &s.Organization,
+		"info.subject.organizationalunit": &s.OrganizationalUnit,
+		"info.subject.commonname":         &s.CommonName,
+		"info.subject.serialnumber":       &s.SerialNumber,
+		"info.subject.domaincomponent":    &s.DomainComponent,
+	}
+	for key, target := range boolFields {
+		if v, ok := fields[key]; ok {
+			if b, err := stringToBool(v); err == nil {
+				*target = b
+				hasField = true
+			}
+		}
+	}
+
+	if !hasField {
+		return nil
+	}
+	return s
+}
+
+func buildTLSIssuerDN(fields map[string]string) *dynamic.TLSClientCertificateIssuerDNInfo {
+	i := &dynamic.TLSClientCertificateIssuerDNInfo{}
+	hasField := false
+
+	boolFields := map[string]*bool{
+		"info.issuer.country":         &i.Country,
+		"info.issuer.province":        &i.Province,
+		"info.issuer.locality":        &i.Locality,
+		"info.issuer.organization":    &i.Organization,
+		"info.issuer.commonname":      &i.CommonName,
+		"info.issuer.serialnumber":    &i.SerialNumber,
+		"info.issuer.domaincomponent": &i.DomainComponent,
+	}
+	for key, target := range boolFields {
+		if v, ok := fields[key]; ok {
+			if b, err := stringToBool(v); err == nil {
+				*target = b
+				hasField = true
+			}
+		}
+	}
+
+	if !hasField {
+		return nil
+	}
+	return i
+}
+
+func buildRetry(fields map[string]string) (*dynamic.Middleware, error) {
+	r := &dynamic.Retry{
+		InitialInterval: fields["initialinterval"],
+	}
+	if v, ok := fields["attempts"]; ok {
+		if n, err := stringToInt(v); err == nil {
+			r.Attempts = n
+		}
+	}
+	return &dynamic.Middleware{Retry: r}, nil
+}
+
+func buildHeaders(fields map[string]string) (*dynamic.Middleware, error) {
+	h := &dynamic.Headers{}
+
+	// String fields
+	stringFields := map[string]*string{
+		"sslhost":                 &h.SSLHost,
+		"customframeoptionsvalue": &h.CustomFrameOptionsValue,
+		"custombrowserxssvalue":   &h.CustomBrowserXSSValue,
+		"contentsecuritypolicy":   &h.ContentSecurityPolicy,
+		"publickey":               &h.PublicKey,
+		"referrerpolicy":          &h.ReferrerPolicy,
+		"featurepolicy":           &h.FeaturePolicy,
+		"permissionspolicy":       &h.PermissionsPolicy,
+	}
+	for key, target := range stringFields {
+		if v, ok := fields[key]; ok {
+			*target = v
+		}
+	}
+
+	// Bool fields
+	boolFields := map[string]*bool{
+		"accesscontrolallowcredentials": &h.AccessControlAllowCredentials,
+		"addvaryheader":                 &h.AddVaryHeader,
+		"sslredirect":                   &h.SSLRedirect,
+		"ssltemporaryredirect":          &h.SSLTemporaryRedirect,
+		"sslforcehost":                  &h.SSLForceHost,
+		"stsincludesubdomains":          &h.STSIncludeSubdomains,
+		"stspreload":                    &h.STSPreload,
+		"forcestsheader":                &h.ForceSTSHeader,
+		"framedeny":                     &h.FrameDeny,
+		"contenttypenosniff":            &h.ContentTypeNosniff,
+		"browserxssfilter":              &h.BrowserXSSFilter,
+		"isdevelopment":                 &h.IsDevelopment,
+	}
+	for key, target := range boolFields {
+		if v, ok := fields[key]; ok {
+			if b, err := stringToBool(v); err == nil {
+				*target = b
+			}
+		}
+	}
+
+	// Int64 fields
+	if v, ok := fields["accesscontrolmaxage"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			h.AccessControlMaxAge = n
+		}
+	}
+	if v, ok := fields["stsseconds"]; ok {
+		if n, err := stringToInt64(v); err == nil {
+			h.STSSeconds = n
+		}
+	}
+
+	// Slice fields
+	sliceFields := map[string]*[]string{
+		"accesscontrolallowheaders":         &h.AccessControlAllowHeaders,
+		"accesscontrolallowmethods":         &h.AccessControlAllowMethods,
+		"accesscontrolalloworiginlist":      &h.AccessControlAllowOriginList,
+		"accesscontrolalloworiginlistregex": &h.AccessControlAllowOriginListRegex,
+		"accesscontrolexposeheaders":        &h.AccessControlExposeHeaders,
+		"allowedhosts":                      &h.AllowedHosts,
+		"hostsproxyheaders":                 &h.HostsProxyHeaders,
+	}
+	for key, target := range sliceFields {
+		if v, ok := fields[key]; ok {
+			*target = splitCommaSeparated(v)
+		}
+	}
+
+	// Map fields: customrequestheaders.*, customresponseheaders.*, sslproxyheaders.*
+	h.CustomRequestHeaders = buildMapFromSubKeys(fields, "customrequestheaders.")
+	h.CustomResponseHeaders = buildMapFromSubKeys(fields, "customresponseheaders.")
+	h.SSLProxyHeaders = buildMapFromSubKeys(fields, "sslproxyheaders.")
+
+	return &dynamic.Middleware{Headers: h}, nil
+}
+
+// buildMapFromSubKeys extracts sub-keys with a given prefix into a map.
+func buildMapFromSubKeys(fields map[string]string, prefix string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range fields {
+		if strings.HasPrefix(k, prefix) {
+			subKey := strings.TrimPrefix(k, prefix)
+			if subKey != "" {
+				result[subKey] = v
+			}
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/provider/middleware_test.go
+++ b/provider/middleware_test.go
@@ -1,0 +1,570 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/NX211/traefik-proxmox-provider/internal"
+)
+
+func TestBuildMiddleware_RedirectRegex(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-redirect.redirectregex.regex":       "^.*$",
+		"traefik.http.middlewares.my-redirect.redirectregex.replacement": "http://192.168.4.165:3000",
+		"traefik.http.middlewares.my-redirect.redirectregex.permanent":   "false",
+	}
+	mw, err := buildMiddleware("redirectregex", labels, "my-redirect")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.RedirectRegex == nil {
+		t.Fatal("expected RedirectRegex to be set")
+	}
+	if mw.RedirectRegex.Regex != "^.*$" {
+		t.Errorf("Regex = %q, want %q", mw.RedirectRegex.Regex, "^.*$")
+	}
+	if mw.RedirectRegex.Replacement != "http://192.168.4.165:3000" {
+		t.Errorf("Replacement = %q, want %q", mw.RedirectRegex.Replacement, "http://192.168.4.165:3000")
+	}
+	if mw.RedirectRegex.Permanent != false {
+		t.Error("Permanent should be false")
+	}
+}
+
+func TestBuildMiddleware_RedirectScheme(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.https-redirect.redirectscheme.scheme":    "https",
+		"traefik.http.middlewares.https-redirect.redirectscheme.permanent": "true",
+		"traefik.http.middlewares.https-redirect.redirectscheme.port":      "443",
+	}
+	mw, err := buildMiddleware("redirectscheme", labels, "https-redirect")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.RedirectScheme == nil {
+		t.Fatal("expected RedirectScheme to be set")
+	}
+	if mw.RedirectScheme.Scheme != "https" {
+		t.Errorf("Scheme = %q, want %q", mw.RedirectScheme.Scheme, "https")
+	}
+	if mw.RedirectScheme.Permanent != true {
+		t.Error("Permanent should be true")
+	}
+	if mw.RedirectScheme.Port != "443" {
+		t.Errorf("Port = %q, want %q", mw.RedirectScheme.Port, "443")
+	}
+}
+
+func TestBuildMiddleware_BasicAuth(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-auth.basicauth.users":        "user1:pass1,user2:pass2",
+		"traefik.http.middlewares.my-auth.basicauth.realm":        "MyRealm",
+		"traefik.http.middlewares.my-auth.basicauth.removeheader": "true",
+	}
+	mw, err := buildMiddleware("basicauth", labels, "my-auth")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.BasicAuth == nil {
+		t.Fatal("expected BasicAuth to be set")
+	}
+	if len(mw.BasicAuth.Users) != 2 {
+		t.Errorf("Users count = %d, want 2", len(mw.BasicAuth.Users))
+	}
+	if mw.BasicAuth.Realm != "MyRealm" {
+		t.Errorf("Realm = %q, want %q", mw.BasicAuth.Realm, "MyRealm")
+	}
+	if !mw.BasicAuth.RemoveHeader {
+		t.Error("RemoveHeader should be true")
+	}
+}
+
+func TestBuildMiddleware_Headers(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-headers.headers.framedeny":                       "true",
+		"traefik.http.middlewares.my-headers.headers.contenttypenosniff":              "true",
+		"traefik.http.middlewares.my-headers.headers.browserxssfilter":                "true",
+		"traefik.http.middlewares.my-headers.headers.stsseconds":                      "31536000",
+		"traefik.http.middlewares.my-headers.headers.stsincludesubdomains":            "true",
+		"traefik.http.middlewares.my-headers.headers.customrequestheaders.x-custom":   "value1",
+		"traefik.http.middlewares.my-headers.headers.customresponseheaders.x-powered": "traefik",
+		"traefik.http.middlewares.my-headers.headers.accesscontrolallowmethods":       "GET,POST,OPTIONS",
+	}
+	mw, err := buildMiddleware("headers", labels, "my-headers")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.Headers == nil {
+		t.Fatal("expected Headers to be set")
+	}
+	if !mw.Headers.FrameDeny {
+		t.Error("FrameDeny should be true")
+	}
+	if !mw.Headers.ContentTypeNosniff {
+		t.Error("ContentTypeNosniff should be true")
+	}
+	if !mw.Headers.BrowserXSSFilter {
+		t.Error("BrowserXSSFilter should be true")
+	}
+	if mw.Headers.STSSeconds != 31536000 {
+		t.Errorf("STSSeconds = %d, want 31536000", mw.Headers.STSSeconds)
+	}
+	if !mw.Headers.STSIncludeSubdomains {
+		t.Error("STSIncludeSubdomains should be true")
+	}
+	if mw.Headers.CustomRequestHeaders == nil || mw.Headers.CustomRequestHeaders["x-custom"] != "value1" {
+		t.Errorf("CustomRequestHeaders[x-custom] = %q, want %q", mw.Headers.CustomRequestHeaders["x-custom"], "value1")
+	}
+	if mw.Headers.CustomResponseHeaders == nil || mw.Headers.CustomResponseHeaders["x-powered"] != "traefik" {
+		t.Errorf("CustomResponseHeaders[x-powered] = %q, want %q", mw.Headers.CustomResponseHeaders["x-powered"], "traefik")
+	}
+	if len(mw.Headers.AccessControlAllowMethods) != 3 {
+		t.Errorf("AccessControlAllowMethods count = %d, want 3", len(mw.Headers.AccessControlAllowMethods))
+	}
+}
+
+func TestBuildMiddleware_Headers_SecurityRegistry(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.security-headers-registry.headers.sslredirect":                  "true",
+		"traefik.http.middlewares.security-headers-registry.headers.framedeny":                    "true",
+		"traefik.http.middlewares.security-headers-registry.headers.contenttypenosniff":           "true",
+		"traefik.http.middlewares.security-headers-registry.headers.browserxssfilter":             "true",
+		"traefik.http.middlewares.security-headers-registry.headers.customframeoptionsvalue":      "SAMEORIGIN",
+		"traefik.http.middlewares.security-headers-registry.headers.accesscontrolallowmethods":    "GET,OPTIONS,PUT",
+		"traefik.http.middlewares.security-headers-registry.headers.accesscontrolalloworiginlist": "https://registry-ui.t.geekosphere.net",
+		"traefik.http.middlewares.security-headers-registry.headers.accesscontrolmaxage":          "100",
+		"traefik.http.middlewares.security-headers-registry.headers.addvaryheader":                "true",
+	}
+	mw, err := buildMiddleware("headers", labels, "security-headers-registry")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.Headers == nil {
+		t.Fatal("expected Headers to be set")
+	}
+	if !mw.Headers.SSLRedirect {
+		t.Error("SSLRedirect should be true")
+	}
+	if !mw.Headers.FrameDeny {
+		t.Error("FrameDeny should be true")
+	}
+	if !mw.Headers.ContentTypeNosniff {
+		t.Error("ContentTypeNosniff should be true")
+	}
+	if !mw.Headers.BrowserXSSFilter {
+		t.Error("BrowserXSSFilter should be true")
+	}
+	if mw.Headers.CustomFrameOptionsValue != "SAMEORIGIN" {
+		t.Errorf("CustomFrameOptionsValue = %q, want %q", mw.Headers.CustomFrameOptionsValue, "SAMEORIGIN")
+	}
+	if len(mw.Headers.AccessControlAllowMethods) != 3 {
+		t.Errorf("AccessControlAllowMethods count = %d, want 3", len(mw.Headers.AccessControlAllowMethods))
+	}
+	if len(mw.Headers.AccessControlAllowOriginList) != 1 || mw.Headers.AccessControlAllowOriginList[0] != "https://registry-ui.t.geekosphere.net" {
+		t.Errorf("AccessControlAllowOriginList = %v, want [https://registry-ui.t.geekosphere.net]", mw.Headers.AccessControlAllowOriginList)
+	}
+	if mw.Headers.AccessControlMaxAge != 100 {
+		t.Errorf("AccessControlMaxAge = %d, want 100", mw.Headers.AccessControlMaxAge)
+	}
+	if !mw.Headers.AddVaryHeader {
+		t.Error("AddVaryHeader should be true")
+	}
+}
+
+func TestBuildMiddleware_Compress(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-compress.compress.excludedcontenttypes": "text/event-stream",
+		"traefik.http.middlewares.my-compress.compress.minresponsebodybytes": "1024",
+	}
+	mw, err := buildMiddleware("compress", labels, "my-compress")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.Compress == nil {
+		t.Fatal("expected Compress to be set")
+	}
+	if len(mw.Compress.ExcludedContentTypes) != 1 || mw.Compress.ExcludedContentTypes[0] != "text/event-stream" {
+		t.Errorf("ExcludedContentTypes = %v, want [text/event-stream]", mw.Compress.ExcludedContentTypes)
+	}
+	if mw.Compress.MinResponseBodyBytes != 1024 {
+		t.Errorf("MinResponseBodyBytes = %d, want 1024", mw.Compress.MinResponseBodyBytes)
+	}
+}
+
+func TestBuildMiddleware_StripPrefix(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-strip.stripprefix.prefixes":   "/api,/v2",
+		"traefik.http.middlewares.my-strip.stripprefix.forceslash": "true",
+	}
+	mw, err := buildMiddleware("stripprefix", labels, "my-strip")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.StripPrefix == nil {
+		t.Fatal("expected StripPrefix to be set")
+	}
+	if len(mw.StripPrefix.Prefixes) != 2 {
+		t.Fatalf("Prefixes count = %d, want 2", len(mw.StripPrefix.Prefixes))
+	}
+	if mw.StripPrefix.Prefixes[0] != "/api" || mw.StripPrefix.Prefixes[1] != "/v2" {
+		t.Errorf("Prefixes = %v, want [/api /v2]", mw.StripPrefix.Prefixes)
+	}
+	if !mw.StripPrefix.ForceSlash {
+		t.Error("ForceSlash should be true")
+	}
+}
+
+func TestBuildMiddleware_Chain(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-chain.chain.middlewares": "auth,compress,headers",
+	}
+	mw, err := buildMiddleware("chain", labels, "my-chain")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.Chain == nil {
+		t.Fatal("expected Chain to be set")
+	}
+	if len(mw.Chain.Middlewares) != 3 {
+		t.Fatalf("Middlewares count = %d, want 3", len(mw.Chain.Middlewares))
+	}
+}
+
+func TestBuildMiddleware_IPAllowList(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-ipallow.ipallowlist.sourcerange":            "10.0.0.0/8,172.16.0.0/12",
+		"traefik.http.middlewares.my-ipallow.ipallowlist.ipstrategy.depth":       "2",
+		"traefik.http.middlewares.my-ipallow.ipallowlist.ipstrategy.excludedips": "127.0.0.1",
+	}
+	mw, err := buildMiddleware("ipallowlist", labels, "my-ipallow")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.IPAllowList == nil {
+		t.Fatal("expected IPAllowList to be set")
+	}
+	if len(mw.IPAllowList.SourceRange) != 2 {
+		t.Errorf("SourceRange count = %d, want 2", len(mw.IPAllowList.SourceRange))
+	}
+	if mw.IPAllowList.IPStrategy == nil {
+		t.Fatal("expected IPStrategy to be set")
+	}
+	if mw.IPAllowList.IPStrategy.Depth != 2 {
+		t.Errorf("Depth = %d, want 2", mw.IPAllowList.IPStrategy.Depth)
+	}
+}
+
+func TestBuildMiddleware_RateLimit(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-rate.ratelimit.average":                          "100",
+		"traefik.http.middlewares.my-rate.ratelimit.burst":                            "50",
+		"traefik.http.middlewares.my-rate.ratelimit.period":                           "1m",
+		"traefik.http.middlewares.my-rate.ratelimit.sourcecriterion.requestheadername": "X-Real-IP",
+	}
+	mw, err := buildMiddleware("ratelimit", labels, "my-rate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.RateLimit == nil {
+		t.Fatal("expected RateLimit to be set")
+	}
+	if mw.RateLimit.Average != 100 {
+		t.Errorf("Average = %d, want 100", mw.RateLimit.Average)
+	}
+	if mw.RateLimit.Burst != 50 {
+		t.Errorf("Burst = %d, want 50", mw.RateLimit.Burst)
+	}
+	if mw.RateLimit.Period != "1m" {
+		t.Errorf("Period = %q, want %q", mw.RateLimit.Period, "1m")
+	}
+	if mw.RateLimit.SourceCriterion == nil {
+		t.Fatal("expected SourceCriterion to be set")
+	}
+	if mw.RateLimit.SourceCriterion.RequestHeaderName != "X-Real-IP" {
+		t.Errorf("RequestHeaderName = %q, want %q", mw.RateLimit.SourceCriterion.RequestHeaderName, "X-Real-IP")
+	}
+}
+
+func TestBuildMiddleware_UnknownType(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.bad.nonexistent.foo": "bar",
+	}
+	_, err := buildMiddleware("nonexistent", labels, "bad")
+	if err == nil {
+		t.Fatal("expected error for unknown middleware type")
+	}
+}
+
+func TestGetLabelsByPrefix(t *testing.T) {
+	config := map[string]string{
+		"traefik.http.middlewares.test.redirectregex.regex":       "^.*$",
+		"traefik.http.middlewares.test.redirectregex.replacement": "http://example.com",
+		"traefik.http.routers.test.rule":                         "Host(`test`)",
+	}
+	result := getLabelsByPrefix(config, "traefik.http.middlewares.test.redirectregex.")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(result))
+	}
+	if result["regex"] != "^.*$" {
+		t.Errorf("regex = %q, want %q", result["regex"], "^.*$")
+	}
+	if result["replacement"] != "http://example.com" {
+		t.Errorf("replacement = %q, want %q", result["replacement"], "http://example.com")
+	}
+}
+
+func TestSplitCommaSeparated(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{"a , b , c", []string{"a", "b", "c"}},
+		{"single", []string{"single"}},
+		{"", []string{}},
+		{" , , ", []string{}},
+	}
+	for _, tt := range tests {
+		result := splitCommaSeparated(tt.input)
+		if len(result) != len(tt.expected) {
+			t.Errorf("splitCommaSeparated(%q) = %v (len %d), want %v (len %d)", tt.input, result, len(result), tt.expected, len(tt.expected))
+			continue
+		}
+		for i := range result {
+			if result[i] != tt.expected[i] {
+				t.Errorf("splitCommaSeparated(%q)[%d] = %q, want %q", tt.input, i, result[i], tt.expected[i])
+			}
+		}
+	}
+}
+
+func TestGenerateConfiguration_WithMiddlewares(t *testing.T) {
+	servicesMap := map[string][]internal.Service{
+		"node1": {
+			{
+				ID:   100,
+				Name: "speedtest",
+				IPs:  []internal.IP{{Address: "192.168.4.165", AddressType: "ipv4"}},
+				Config: map[string]string{
+					"traefik.enable":                                                        "true",
+					"traefik.http.routers.speedtest.rule":                                   "Host(`speedtest.example.com`)",
+					"traefik.http.routers.speedtest.middlewares":                             "speedtest-redirect",
+					"traefik.http.services.speedtest.loadbalancer.server.port":               "3000",
+					"traefik.http.middlewares.speedtest-redirect.redirectregex.regex":         "^.*$",
+					"traefik.http.middlewares.speedtest-redirect.redirectregex.replacement":   "http://192.168.4.165:3000",
+					"traefik.http.middlewares.speedtest-redirect.redirectregex.permanent":     "false",
+				},
+			},
+		},
+	}
+
+	config := generateConfiguration(servicesMap)
+
+	if len(config.HTTP.Middlewares) != 1 {
+		t.Fatalf("expected 1 middleware, got %d", len(config.HTTP.Middlewares))
+	}
+
+	mw, ok := config.HTTP.Middlewares["speedtest-redirect"]
+	if !ok {
+		t.Fatal("expected middleware 'speedtest-redirect' to exist")
+	}
+	if mw.RedirectRegex == nil {
+		t.Fatal("expected RedirectRegex to be set")
+	}
+	if mw.RedirectRegex.Regex != "^.*$" {
+		t.Errorf("Regex = %q, want %q", mw.RedirectRegex.Regex, "^.*$")
+	}
+	if mw.RedirectRegex.Replacement != "http://192.168.4.165:3000" {
+		t.Errorf("Replacement = %q, want %q", mw.RedirectRegex.Replacement, "http://192.168.4.165:3000")
+	}
+
+	router, ok := config.HTTP.Routers["speedtest"]
+	if !ok {
+		t.Fatal("expected router 'speedtest' to exist")
+	}
+	if len(router.Middlewares) != 1 || router.Middlewares[0] != "speedtest-redirect" {
+		t.Errorf("router middlewares = %v, want [speedtest-redirect]", router.Middlewares)
+	}
+}
+
+func TestGenerateConfiguration_MultipleMiddlewares(t *testing.T) {
+	servicesMap := map[string][]internal.Service{
+		"node1": {
+			{
+				ID:   200,
+				Name: "webapp",
+				IPs:  []internal.IP{{Address: "10.0.0.5", AddressType: "ipv4"}},
+				Config: map[string]string{
+					"traefik.enable":                                                       "true",
+					"traefik.http.routers.webapp.rule":                                     "Host(`webapp.example.com`)",
+					"traefik.http.routers.webapp.middlewares":                               "my-compress,my-headers",
+					"traefik.http.services.webapp.loadbalancer.server.port":                 "8080",
+					"traefik.http.middlewares.my-compress.compress.minresponsebodybytes":    "512",
+					"traefik.http.middlewares.my-headers.headers.framedeny":                 "true",
+					"traefik.http.middlewares.my-headers.headers.customrequestheaders.x-app": "test",
+				},
+			},
+		},
+	}
+
+	config := generateConfiguration(servicesMap)
+
+	if len(config.HTTP.Middlewares) != 2 {
+		t.Fatalf("expected 2 middlewares, got %d", len(config.HTTP.Middlewares))
+	}
+
+	compress, ok := config.HTTP.Middlewares["my-compress"]
+	if !ok {
+		t.Fatal("expected middleware 'my-compress' to exist")
+	}
+	if compress.Compress == nil {
+		t.Fatal("expected Compress to be set")
+	}
+	if compress.Compress.MinResponseBodyBytes != 512 {
+		t.Errorf("MinResponseBodyBytes = %d, want 512", compress.Compress.MinResponseBodyBytes)
+	}
+
+	headers, ok := config.HTTP.Middlewares["my-headers"]
+	if !ok {
+		t.Fatal("expected middleware 'my-headers' to exist")
+	}
+	if headers.Headers == nil {
+		t.Fatal("expected Headers to be set")
+	}
+	if !headers.Headers.FrameDeny {
+		t.Error("FrameDeny should be true")
+	}
+	if headers.Headers.CustomRequestHeaders["x-app"] != "test" {
+		t.Errorf("CustomRequestHeaders[x-app] = %q, want %q", headers.Headers.CustomRequestHeaders["x-app"], "test")
+	}
+}
+
+func TestBuildMiddleware_ForwardAuth(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-fwd.forwardauth.address":                "http://auth.example.com",
+		"traefik.http.middlewares.my-fwd.forwardauth.trustforwardheader":     "true",
+		"traefik.http.middlewares.my-fwd.forwardauth.authresponseheaders":    "X-Auth-User,X-Auth-Role",
+		"traefik.http.middlewares.my-fwd.forwardauth.tls.insecureskipverify": "true",
+	}
+	mw, err := buildMiddleware("forwardauth", labels, "my-fwd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.ForwardAuth == nil {
+		t.Fatal("expected ForwardAuth to be set")
+	}
+	if mw.ForwardAuth.Address != "http://auth.example.com" {
+		t.Errorf("Address = %q, want %q", mw.ForwardAuth.Address, "http://auth.example.com")
+	}
+	if !mw.ForwardAuth.TrustForwardHeader {
+		t.Error("TrustForwardHeader should be true")
+	}
+	if len(mw.ForwardAuth.AuthResponseHeaders) != 2 {
+		t.Errorf("AuthResponseHeaders count = %d, want 2", len(mw.ForwardAuth.AuthResponseHeaders))
+	}
+	if mw.ForwardAuth.TLS == nil {
+		t.Fatal("expected TLS to be set")
+	}
+	if !mw.ForwardAuth.TLS.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should be true")
+	}
+}
+
+func TestBuildMiddleware_Retry(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-retry.retry.attempts":        "3",
+		"traefik.http.middlewares.my-retry.retry.initialinterval": "100ms",
+	}
+	mw, err := buildMiddleware("retry", labels, "my-retry")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.Retry == nil {
+		t.Fatal("expected Retry to be set")
+	}
+	if mw.Retry.Attempts != 3 {
+		t.Errorf("Attempts = %d, want 3", mw.Retry.Attempts)
+	}
+	if mw.Retry.InitialInterval != "100ms" {
+		t.Errorf("InitialInterval = %q, want %q", mw.Retry.InitialInterval, "100ms")
+	}
+}
+
+func TestBuildMiddleware_AddPrefix(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-prefix.addprefix.prefix": "/api",
+	}
+	mw, err := buildMiddleware("addprefix", labels, "my-prefix")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.AddPrefix == nil {
+		t.Fatal("expected AddPrefix to be set")
+	}
+	if mw.AddPrefix.Prefix != "/api" {
+		t.Errorf("Prefix = %q, want %q", mw.AddPrefix.Prefix, "/api")
+	}
+}
+
+func TestBuildMiddleware_Buffering(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-buf.buffering.maxrequestbodybytes":  "1048576",
+		"traefik.http.middlewares.my-buf.buffering.maxresponsebodybytes": "2097152",
+		"traefik.http.middlewares.my-buf.buffering.retryexpression":      "IsNetworkError()",
+	}
+	mw, err := buildMiddleware("buffering", labels, "my-buf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.Buffering == nil {
+		t.Fatal("expected Buffering to be set")
+	}
+	if mw.Buffering.MaxRequestBodyBytes != 1048576 {
+		t.Errorf("MaxRequestBodyBytes = %d, want 1048576", mw.Buffering.MaxRequestBodyBytes)
+	}
+	if mw.Buffering.MaxResponseBodyBytes != 2097152 {
+		t.Errorf("MaxResponseBodyBytes = %d, want 2097152", mw.Buffering.MaxResponseBodyBytes)
+	}
+	if mw.Buffering.RetryExpression != "IsNetworkError()" {
+		t.Errorf("RetryExpression = %q, want %q", mw.Buffering.RetryExpression, "IsNetworkError()")
+	}
+}
+
+func TestBuildMiddleware_CircuitBreaker(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-cb.circuitbreaker.expression": "NetworkErrorRatio() > 0.5",
+	}
+	mw, err := buildMiddleware("circuitbreaker", labels, "my-cb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.CircuitBreaker == nil {
+		t.Fatal("expected CircuitBreaker to be set")
+	}
+	if mw.CircuitBreaker.Expression != "NetworkErrorRatio() > 0.5" {
+		t.Errorf("Expression = %q, want %q", mw.CircuitBreaker.Expression, "NetworkErrorRatio() > 0.5")
+	}
+}
+
+func TestBuildMiddleware_ErrorPage(t *testing.T) {
+	labels := map[string]string{
+		"traefik.http.middlewares.my-errors.errors.status":  "500-599",
+		"traefik.http.middlewares.my-errors.errors.service": "error-svc",
+		"traefik.http.middlewares.my-errors.errors.query":   "/{status}.html",
+	}
+	mw, err := buildMiddleware("errors", labels, "my-errors")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.Errors == nil {
+		t.Fatal("expected Errors to be set")
+	}
+	if mw.Errors.Service != "error-svc" {
+		t.Errorf("Service = %q, want %q", mw.Errors.Service, "error-svc")
+	}
+	if mw.Errors.Query != "/{status}.html" {
+		t.Errorf("Query = %q, want %q", mw.Errors.Query, "/{status}.html")
+	}
+	if len(mw.Errors.Status) != 1 || mw.Errors.Status[0] != "500-599" {
+		t.Errorf("Status = %v, want [500-599]", mw.Errors.Status)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -340,10 +340,11 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 				continue
 			}
 			
-			// Extract router and service names from labels
+			// Extract router, service, and middleware names from labels
 			routerPrefixMap := make(map[string]bool)
 			servicePrefixMap := make(map[string]bool)
-			
+			middlewarePrefixMap := make(map[string]string) // name -> type
+
 			for k := range service.Config {
 				if strings.HasPrefix(k, "traefik.http.routers.") {
 					parts := strings.Split(k, ".")
@@ -355,6 +356,12 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 					parts := strings.Split(k, ".")
 					if len(parts) > 3 {
 						servicePrefixMap[parts[3]] = true
+					}
+				}
+				if strings.HasPrefix(k, "traefik.http.middlewares.") {
+					parts := strings.Split(k, ".")
+					if len(parts) >= 5 {
+						middlewarePrefixMap[parts[3]] = parts[4]
 					}
 				}
 			}
@@ -421,6 +428,17 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 				config.HTTP.Routers[routerName] = router
 			}
 			
+			// Create middlewares
+			for mwName, mwType := range middlewarePrefixMap {
+				mw, err := buildMiddleware(mwType, service.Config, mwName)
+				if err != nil {
+					log.Printf("ERROR: Failed to build middleware %s (type %s): %v", mwName, mwType, err)
+					continue
+				}
+				config.HTTP.Middlewares[mwName] = mw
+				log.Printf("Created middleware %s (type %s)", mwName, mwType)
+			}
+
 			log.Printf("Created router and service for %s (ID: %d)", service.Name, service.ID)
 		}
 	}


### PR DESCRIPTION
Just found this plugin after your post to Reddit, and am loving it thanks! 
I tried to use it with 2 of my LXCs (one LXC one OCI) and I was not able to create a dynamic middleware, for my headers or a redirect. Being a Software Architect/Developer for 30+ years I figured I would give this a shot with the help of Claude (as I am not a golang developer) I was able to dynamically add my two middlewares with no issues when running this as a `plugins-local` on my Traefik LXC on Proxmox VE 9.1.4.
Thanks again for the work in setting up the plugin!
