### PR TITLE
Feature/multi node support

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -14,7 +14,7 @@ testData:
   apiLogging: "info"
   apiValidateSSL: "true"
 
-# Sample provider configuration
+# Sample provider configuration (single node)
 providers:
   plugin:
     traefik-proxmox-provider:
@@ -24,3 +24,20 @@ providers:
       apiToken: "00000000-0000-0000-0000-000000000000"
       apiLogging: "debug"
       apiValidateSSL: "false"
+
+# Sample provider configuration (multiple nodes/clusters)
+# providers:
+#   plugin:
+#     traefik-proxmox-provider:
+#       pollInterval: "5s"
+#       nodes:
+#         - name: "cluster1"
+#           apiEndpoint: "https://pve1.example.com:8006"
+#           apiTokenId: "root@pam!traefik"
+#           apiToken: "00000000-0000-0000-0000-000000000001"
+#           apiValidateSSL: "true"
+#         - name: "cluster2"
+#           apiEndpoint: "https://pve2.example.com:8006"
+#           apiTokenId: "root@pam!traefik"
+#           apiToken: "00000000-0000-0000-0000-000000000002"
+#           apiValidateSSL: "false"


### PR DESCRIPTION
Add a 'nodes' config array that allows configuring multiple independent Proxmox API endpoints within a single plugin instance. Each entry gets its own API client and is polled independently. Results are merged into a single Traefik dynamic configuration.

When multiple nodes are configured, auto-generated fallback IDs (used only when VMs have no explicit router/service names in their traefik labels) are prefixed with the node name to prevent collisions across clusters. Explicit label-defined names are not prefixed.

The existing single-endpoint flat config (apiEndpoint, apiTokenId, etc.) is preserved for full backward compatibility.

Tested using the localPlugin plugin source on a traefik instance hosted on a proxmox LXC (Node 1). Successfully reads container information from the host proxmox node, and a second node (Node 2) on the same LAN.