### PR TITLE
docs: set version to v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ experimental:
   plugins:
     traefik-proxmox-provider:
       moduleName: github.com/NX211/traefik-proxmox-provider
-      version: v0.7.0
+      version: v0.8.1
 ```
 
 2. Configure the provider in your dynamic configuration:


### PR DESCRIPTION
Updated the plugin version in readme so others don't waste time like i did trying to figure out why it was resolving to a hostname instead of an ip address (v0.7.0 does not include #17 )