### PR TITLE
Fix 9 correctness bugs (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [Unreleased]
+
+### Breaking
+
+- **Router and service names emitted by this provider are now suffixed with `-<vmid>`.**
+  Previously, two guests that both used the same router/service name (e.g.
+  `traefik.http.routers.app.rule=…`) silently overwrote each other in the
+  generated config. Names are now namespaced by Proxmox VMID — `app` becomes
+  `app-101`. **Migration:** any external Traefik config that referenced these
+  names by their bare form (for example, a middleware chain in the file
+  provider pointing at `app@plugin-traefik-proxmox-provider`) must be updated
+  to the suffixed name. Routing behavior is otherwise unchanged.
+
+### Fixed
+
+- **Router priority no longer hardcoded.** Routers were emitted with
+  `Priority: 1`, which defeats Traefik's rule-length-based default ordering
+  and causes nondeterministic match order when multiple rules tied at 1.
+  Priority is now left at 0 (omitted) unless an explicit
+  `traefik.http.routers.<n>.priority` label is set.
+- **`traefik.enable=1` now works.** The boolean check matched only the literal
+  string `"true"`. It now uses `strconv.ParseBool` to match Traefik's own
+  Docker provider semantics (`1`, `t`, `T`, `true`, `True`, `TRUE` are all
+  truthy; `yes`/`on` are intentionally not accepted).
+- **Multi-IP guests are now load-balanced.** Previously only the first
+  discovered IP was added as a backend; the remaining IPs were dropped on the
+  floor. Each guest-agent IP now becomes its own `Server` entry in the load
+  balancer, sorted lexicographically for stable output across polls.
+- **Router→service binding is now deterministic.** `mapKeysToSlice` returned
+  map keys in random iteration order, so the default-target service for a
+  router with no explicit `…service=` label could flap between polls.
+- **Offline Proxmox nodes are now skipped.** The plugin now reads `status`
+  from `/nodes` and skips any node not reported as `online`, instead of
+  failing through to a noisy per-cycle scan error.
+- **Better diagnostics for PVE 9 token-role errors.** Proxmox VE 9 removed
+  the `VM.Monitor` privilege and replaced it with `VM.GuestAgent.Audit`.
+  Tokens carrying the old role now get a one-shot warning per VM pointing at
+  the README's "Proxmox API Token Setup" section instead of an opaque
+  generic 403.
+- **Router/service names containing dots are now rejected.** Previously the
+  parser silently truncated `traefik.http.routers.my.app.rule` to a router
+  named `my`. Such labels now log a warning and are skipped.
+- **TLS-domain regex no longer recompiled on every poll.** Hoisted to a
+  package-level `var`.
+
+### Added
+
+- Typed sentinel errors in `internal` (`ErrUnauthorized`, `ErrForbidden`,
+  `ErrBadRequest`, `ErrServerError`) for callers that need to disambiguate
+  Proxmox API failure modes via `errors.Is`.
+- Substantially expanded test coverage for `generateConfiguration`,
+  `applyRouterOptions`, `extractLabelName`, `mapKeysToSlice`,
+  `isBoolLabelEnabled`, and the multi-IP fanout in `getServiceURLs`.
+
 ## [v0.7.0] - 2024-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ Make sure to save the API token value when it's displayed, as it won't be shown 
 
 The provider looks for Traefik labels in the VM/container notes field. Each line in the Notes field starting with `traefik.` will be treated as a Traefik label.
 
+### Naming rules (important)
+
+- **Router and service names are namespaced by Proxmox VMID.** A label like
+  `traefik.http.routers.app.rule=…` on VMID 101 produces a router named
+  `app-101` in the generated Traefik config (and `app-101@plugin-…` in the
+  Traefik dashboard). This prevents silent collisions when two guests use the
+  same router or service name. Same-guest cross-references via
+  `traefik.http.routers.<r>.service=<svc>` are rewritten automatically.
+  Foreign references such as `…service=external@file` are passed through
+  unchanged.
+- **Names must not contain dots.** `traefik.http.routers.my.app.rule=…` is
+  ambiguous (is the name `my` with sub-key `app.rule`, or `my.app` with
+  sub-key `rule`?) and will be rejected with a warning in the Traefik log.
+  Use `myapp` or `my-app` instead.
+- **`traefik.enable` is parsed via Go's `strconv.ParseBool`.** Accepted truthy
+  values: `1`, `t`, `T`, `true`, `True`, `TRUE`. `yes` and `on` are not
+  accepted (this matches Traefik's own Docker provider).
+
 ### Required Labels
 
 - `traefik.enable=true` - Without this label, the VM/container will be ignored
@@ -249,6 +267,15 @@ If your services aren't being discovered:
    ```
 4. **Check token permissions**: Verify in Proxmox UI under **Datacenter → Permissions → API Tokens**
 5. **Provider config location**: The plugin config belongs in Traefik's **static** config (`traefik.yaml`), not dynamic config
+6. **`WARN: 403 Forbidden from Proxmox network-interface API` in the log**:
+   Your API token role is missing the privilege required to read VM network
+   interfaces. On **Proxmox VE 9** this is `VM.GuestAgent.Audit` (the legacy
+   `VM.Monitor` privilege was removed). On PVE 8 it is `VM.Monitor`. See
+   "Proxmox API Token Setup" above for the exact `pveum` commands.
+7. **`Ignoring label … router/service name must be a single token without dots`**:
+   You have a router or service name that contains a dot (e.g.
+   `traefik.http.routers.my.app.rule=…`). Names with dots are ambiguous and
+   are skipped. Use `myapp` or `my-app` instead.
 
 ## Contributing
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -18,6 +19,32 @@ const (
 	LogLevelInfo  = "info"
 	LogLevelDebug = "debug"
 )
+
+// Sentinel errors used to classify Proxmox API responses by HTTP status.
+// Callers can check with errors.Is to disambiguate (e.g. permission errors
+// vs. agent-not-running) and emit better diagnostics.
+var (
+	ErrUnauthorized = errors.New("proxmox: unauthorized")
+	ErrForbidden    = errors.New("proxmox: forbidden")
+	ErrBadRequest   = errors.New("proxmox: bad request")
+	ErrServerError  = errors.New("proxmox: server error")
+)
+
+// sentinelForStatus returns the matching sentinel for an HTTP status code,
+// or nil for codes we don't classify.
+func sentinelForStatus(code int) error {
+	switch {
+	case code == http.StatusUnauthorized:
+		return ErrUnauthorized
+	case code == http.StatusForbidden:
+		return ErrForbidden
+	case code == http.StatusBadRequest:
+		return ErrBadRequest
+	case code >= 500 && code < 600:
+		return ErrServerError
+	}
+	return nil
+}
 
 // ProxmoxClient represents a client to the Proxmox API
 type ProxmoxClient struct {
@@ -92,6 +119,10 @@ func (c *ProxmoxClient) Do(ctx context.Context, method, path string, body interf
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(resp.Body)
+		if sentinel := sentinelForStatus(resp.StatusCode); sentinel != nil {
+			return fmt.Errorf("API request failed with status %d: %s: %w",
+				resp.StatusCode, string(respBody), sentinel)
+		}
 		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
 	}
 

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientDo_StatusErrorsWrapSentinels(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		sentinel error
+		body     string
+	}{
+		{"401 unauthorized", http.StatusUnauthorized, ErrUnauthorized, `{"errors":{"auth":"failed"}}`},
+		{"403 forbidden", http.StatusForbidden, ErrForbidden, `{"errors":{"perm":"denied"}}`},
+		{"400 bad request", http.StatusBadRequest, ErrBadRequest, `{"errors":{"x":"y"}}`},
+		{"500 server error", http.StatusInternalServerError, ErrServerError, `internal error`},
+		{"503 server error", http.StatusServiceUnavailable, ErrServerError, `down`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			c := NewProxmoxClient(srv.URL, "tok@pam!t", "secret", false, "info")
+			// Override BaseURL: NewProxmoxClient appends /api2/json which the
+			// stub server does not need; reset to the bare URL.
+			c.BaseURL = srv.URL
+
+			err := c.Get(context.Background(), "/anything", nil)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, tt.sentinel) {
+				t.Errorf("err = %v\nwant errors.Is(err, %v) == true", err, tt.sentinel)
+			}
+		})
+	}
+}
+
+func TestClientDo_2xxNoSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"release":"8.0.0"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewProxmoxClient(srv.URL, "tok@pam!t", "secret", false, "info")
+	c.BaseURL = srv.URL
+
+	var resp struct {
+		Data Version `json:"data"`
+	}
+	if err := c.Get(context.Background(), "/version", &resp); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Data.Release != "8.0.0" {
+		t.Errorf("Release = %q, want 8.0.0", resp.Data.Release)
+	}
+}

--- a/internal/models.go
+++ b/internal/models.go
@@ -15,7 +15,8 @@ type ParsedAgentInterfaces struct {
 }
 
 type NodeStatus struct {
-	Node string `json:"node"`
+	Node   string `json:"node"`
+	Status string `json:"status"`
 }
 
 type VirtualMachine struct {

--- a/internal/service_test.go
+++ b/internal/service_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -203,4 +204,32 @@ func TestParsedAgentInterfaces_GetIPs(t *testing.T) {
 	if ips[1].Address != "10.0.0.1" {
 		t.Errorf("Expected second IP to be 10.0.0.1, got %s", ips[1].Address)
 	}
-} 
+}
+
+func TestNodeStatus_JSONUnmarshal(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantNode   string
+		wantStatus string
+	}{
+		{"online node", `{"node":"pve1","status":"online"}`, "pve1", "online"},
+		{"offline node", `{"node":"pve2","status":"offline"}`, "pve2", "offline"},
+		{"unknown node", `{"node":"pve3","status":"unknown"}`, "pve3", "unknown"},
+		{"missing status", `{"node":"pve4"}`, "pve4", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ns NodeStatus
+			if err := json.Unmarshal([]byte(tt.raw), &ns); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if ns.Node != tt.wantNode {
+				t.Errorf("Node = %q, want %q", ns.Node, tt.wantNode)
+			}
+			if ns.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", ns.Status, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/NX211/traefik-proxmox-provider/internal"
@@ -135,7 +136,8 @@ func (p *Provider) updateConfiguration(ctx context.Context, cfgChan chan<- json.
 		return fmt.Errorf("error getting service map: %w", err)
 	}
 
-	configuration := generateConfiguration(servicesMap)
+	debug := p.client.LogLevel == internal.LogLevelDebug
+	configuration := generateConfiguration(servicesMap, debug)
 	cfgChan <- &dynamic.JSONPayload{Configuration: configuration}
 	return nil
 }
@@ -192,6 +194,13 @@ func getServiceMap(client *internal.ProxmoxClient, ctx context.Context) (map[str
 	}
 
 	for _, nodeStatus := range nodes {
+		// Skip nodes that Proxmox reports as not online. Empty status falls
+		// through (treated as online) to preserve historic behavior on older
+		// Proxmox versions that may not return the field.
+		if nodeStatus.Status != "" && nodeStatus.Status != "online" {
+			log.Printf("Skipping node %s: status=%s", nodeStatus.Node, nodeStatus.Status)
+			continue
+		}
 		services, err := scanServices(client, ctx, nodeStatus.Node)
 		if err != nil {
 			log.Printf("Error scanning services on node %s: %v", nodeStatus.Node, err)
@@ -202,17 +211,49 @@ func getServiceMap(client *internal.ProxmoxClient, ctx context.Context) (map[str
 	return servicesMap, nil
 }
 
+// forbiddenWarnedVMIDs records VMIDs for which we've already emitted the
+// "PVE 9 token role" hint, so the warning fires once per VM per process
+// instead of on every poll.
+var forbiddenWarnedVMIDs sync.Map
+
+// maybeWarnForbidden emits a one-shot upgrade hint when the Proxmox API
+// returned 403 for a guest's network-interface lookup. The most common cause
+// in the field is a Proxmox VE 8 → 9 upgrade: PVE 9 removed the `VM.Monitor`
+// privilege and split it into granular ones, so existing API tokens lose
+// access to the QEMU guest-agent endpoint until `VM.GuestAgent.Audit` is
+// added to their role.
+func maybeWarnForbidden(err error, vmID uint64, isContainer bool) {
+	if !errors.Is(err, internal.ErrForbidden) {
+		return
+	}
+	if _, loaded := forbiddenWarnedVMIDs.LoadOrStore(vmID, struct{}{}); loaded {
+		return
+	}
+	kind := "VM"
+	if isContainer {
+		kind = "container"
+	}
+	log.Printf(
+		"WARN: 403 Forbidden from Proxmox network-interface API for %s %d. "+
+			"If you upgraded to Proxmox VE 9, your API token role likely needs `VM.GuestAgent.Audit` "+
+			"(VMs) and `VM.Audit` (containers). See README \"Proxmox API Token Setup\".",
+		kind, vmID,
+	)
+}
+
 func getIPsOfService(client *internal.ProxmoxClient, ctx context.Context, nodeName string, vmID uint64, isContainer bool) (ips []internal.IP, err error) {
 	var agentInterfaces *internal.ParsedAgentInterfaces
 	if isContainer {
 		agentInterfaces, err = client.GetContainerNetworkInterfaces(ctx, nodeName, vmID)
 		if err != nil {
+			maybeWarnForbidden(err, vmID, true)
 			log.Printf("ERROR: Error getting container network interfaces for %s/%d: %v", nodeName, vmID, err)
 			return nil, fmt.Errorf("error getting container network interfaces: %w", err)
 		}
 	} else {
 		agentInterfaces, err = client.GetVMNetworkInterfaces(ctx, nodeName, vmID)
 		if err != nil {
+			maybeWarnForbidden(err, vmID, false)
 			log.Printf("ERROR: Error getting VM network interfaces for %s/%d: %v", nodeName, vmID, err)
 			return nil, fmt.Errorf("error getting VM network interfaces: %w", err)
 		}
@@ -242,7 +283,7 @@ func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName 
 	}
 
 	for _, vm := range vms {
-		if client.LogLevel == "debug" {
+		if client.LogLevel == internal.LogLevelDebug {
 			log.Printf("DEBUG: Scanning VM %s/%s (%d): %s", nodeName, vm.Name, vm.VMID, vm.Status)
 		}
 		
@@ -254,7 +295,7 @@ func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName 
 			}
 			
 			traefikConfig := config.GetTraefikMap()
-			if client.LogLevel == "debug" {
+			if client.LogLevel == internal.LogLevelDebug {
 				log.Printf("VM %s (%d) traefik config: %v", vm.Name, vm.VMID, traefikConfig)
 			}
 			
@@ -276,7 +317,7 @@ func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName 
 	}
 
 	for _, ct := range cts {
-		if client.LogLevel == "debug" {
+		if client.LogLevel == internal.LogLevelDebug {
 			log.Printf("DEBUG: Scanning container %s/%s (%d): %s", nodeName, ct.Name, ct.VMID, ct.Status)
 		}
 			
@@ -289,7 +330,7 @@ func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName 
 			}
 
 			traefikConfig := config.GetTraefikMap()
-			if client.LogLevel == "debug" {
+			if client.LogLevel == internal.LogLevelDebug {
 				log.Printf("DEBUG: Container %s (%d) traefik config: %v", ct.Name, ct.VMID, traefikConfig)
 			}
 
@@ -308,7 +349,11 @@ func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName 
 	return services, nil
 }
 
-func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.Configuration {
+// generateConfiguration translates the per-node service map into a Traefik
+// dynamic configuration. The `debug` flag controls verbose per-cycle logging
+// (skipped/created services, IP fallbacks). Errors and warnings are emitted
+// regardless of debug.
+func generateConfiguration(servicesMap map[string][]internal.Service, debug bool) *dynamic.Configuration {
 	config := &dynamic.Configuration{
 		HTTP: &dynamic.HTTPConfiguration{
 			Routers:           make(map[string]*dynamic.Router),
@@ -336,36 +381,46 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 		for _, service := range services {
 			// Skip disabled services
 			if len(service.Config) == 0 || !isBoolLabelEnabled(service.Config, "traefik.enable") {
-				log.Printf("Skipping service %s (ID: %d) because traefik.enable is not true", service.Name, service.ID)
+				if debug {
+					log.Printf("Skipping service %s (ID: %d) because traefik.enable is not true", service.Name, service.ID)
+				}
 				continue
 			}
 			
-			// Extract router and service names from labels
+			// Extract router and service names from labels. Names that contain
+			// dots are rejected (warn-and-skip) because we cannot disambiguate
+			// `routers.my.app.rule` ("router my, sub-key app.rule") from
+			// ("router my.app, sub-key rule") without a complete sub-key
+			// registry.
 			routerPrefixMap := make(map[string]bool)
 			servicePrefixMap := make(map[string]bool)
-			
+
 			for k := range service.Config {
 				if strings.HasPrefix(k, "traefik.http.routers.") {
-					parts := strings.Split(k, ".")
-					if len(parts) > 3 {
-						routerPrefixMap[parts[3]] = true
+					name, ok := extractLabelName(k, "traefik.http.routers.", routerSubkeyAllowList)
+					if !ok {
+						log.Printf("Ignoring label %q on %s (ID %d): router name must be a single token without dots", k, service.Name, service.ID)
+						continue
 					}
+					routerPrefixMap[name] = true
 				}
 				if strings.HasPrefix(k, "traefik.http.services.") {
-					parts := strings.Split(k, ".")
-					if len(parts) > 3 {
-						servicePrefixMap[parts[3]] = true
+					name, ok := extractLabelName(k, "traefik.http.services.", serviceSubkeyAllowList)
+					if !ok {
+						log.Printf("Ignoring label %q on %s (ID %d): service name must be a single token without dots", k, service.Name, service.ID)
+						continue
 					}
+					servicePrefixMap[name] = true
 				}
 			}
 			
-			// Default to service ID if no names found
+			// Default to "<name>-<vmid>" if no explicit names found in labels.
 			defaultID := fmt.Sprintf("%s-%d", service.Name, service.ID)
-			
-			// Convert maps to slices
+
+			// Convert maps to (sorted) slices
 			routerNames := mapKeysToSlice(routerPrefixMap)
 			serviceNames := mapKeysToSlice(servicePrefixMap)
-			
+
 			// Use defaults if no names found
 			if len(routerNames) == 0 {
 				routerNames = []string{defaultID}
@@ -373,7 +428,30 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 			if len(serviceNames) == 0 {
 				serviceNames = []string{defaultID}
 			}
-			
+
+			// Namespacing: VMID is cluster-wide unique in Proxmox, so suffixing
+			// user-supplied router/service names with "-<vmid>" makes them
+			// globally unique and prevents silent overwrites when multiple
+			// guests share the same router/service name (e.g. "app").
+			//
+			// The defaultID branch already includes the VMID, so we leave
+			// it untouched to avoid producing keys like "web-101-101".
+			ns := func(name string) string {
+				if name == defaultID {
+					return name
+				}
+				return fmt.Sprintf("%s-%d", name, service.ID)
+			}
+
+			// Build a set of services declared on THIS guest. Used below to
+			// rewrite same-guest router→service cross-references; references
+			// to services not in this set are passed through verbatim, since
+			// they may point at the file/static config (e.g. "external@file").
+			localServices := make(map[string]bool, len(serviceNames))
+			for _, s := range serviceNames {
+				localServices[s] = true
+			}
+
 			// Create services
 			for _, serviceName := range serviceNames {
 				// Configure load balancer options
@@ -381,47 +459,60 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 					PassHostHeader: boolPtr(true), // Default is true
 					Servers:        []dynamic.Server{},
 				}
-				
-				// Apply service options
+
+				// Apply service options. Note: helpers below take the ORIGINAL
+				// (un-namespaced) name because they look up labels in
+				// service.Config, which is keyed by the original.
 				applyServiceOptions(loadBalancer, service, serviceName)
-				
-				// Add server URL(s)
-				serverURL := getServiceURL(service, serviceName, nodeName)
-				loadBalancer.Servers = append(loadBalancer.Servers, dynamic.Server{
-					URL: serverURL,
-				})
-				
-				config.HTTP.Services[serviceName] = &dynamic.Service{
+
+				// Add one Server entry per discovered backend URL.
+				for _, u := range getServiceURLs(service, serviceName, nodeName, debug) {
+					loadBalancer.Servers = append(loadBalancer.Servers, dynamic.Server{URL: u})
+				}
+
+				config.HTTP.Services[ns(serviceName)] = &dynamic.Service{
 					LoadBalancer: loadBalancer,
 				}
 			}
-			
+
 			// Create routers
 			for _, routerName := range routerNames {
-				// Get router rule
+				// Get router rule (original name — reads labels)
 				rule := getRouterRule(service, routerName)
-				
-				// Find target service (prefer explicit mapping)
-				targetService := serviceNames[0]
+
+				// Find target service. Prefer the explicit `…service=<svc>`
+				// mapping; if it points at a service declared on this same
+				// guest, rewrite it to the namespaced form so the link still
+				// resolves after we suffix names with -<vmid>. Otherwise the
+				// reference is foreign (e.g. "external@file") and stays as-is.
+				targetService := ns(serviceNames[0])
 				serviceLabel := fmt.Sprintf("traefik.http.routers.%s.service", routerName)
 				if val, exists := service.Config[serviceLabel]; exists {
-					targetService = val
+					if localServices[val] {
+						targetService = ns(val)
+					} else {
+						targetService = val
+					}
 				}
-				
-				// Create basic router
+
+				// Create basic router. Leave Priority unset (zero) so Traefik
+				// applies its default rule-length-based ordering. The
+				// applyRouterOptions call below will set Priority if the user
+				// provides an explicit `…priority=N` label.
 				router := &dynamic.Router{
-					Service:  targetService,
-					Rule:     rule,
-					Priority: 1, // Default priority
+					Service: targetService,
+					Rule:    rule,
 				}
-				
-				// Apply additional router options from labels
+
+				// Apply additional router options from labels (original name).
 				applyRouterOptions(router, service, routerName)
-				
-				config.HTTP.Routers[routerName] = router
+
+				config.HTTP.Routers[ns(routerName)] = router
 			}
-			
-			log.Printf("Created router and service for %s (ID: %d)", service.Name, service.ID)
+
+			if debug {
+				log.Printf("Created router and service for %s (ID: %d)", service.Name, service.ID)
+			}
 		}
 	}
 	
@@ -523,6 +614,67 @@ func applyServiceOptions(lb *dynamic.ServersLoadBalancer, service internal.Servi
 	}
 }
 
+// tlsDomainPattern matches array-indexed TLS domain labels of the form
+// `…tls.domains[N].main` or `…tls.domains[N].sans`. Compiled once at package
+// init to avoid recompiling on every poll cycle.
+var tlsDomainPattern = regexp.MustCompile(`\.tls\.domains\[(\d+)\]\.(main|sans)$`)
+
+// routerSubkeyAllowList is the set of first-segment subkeys that may follow a
+// router name in a `traefik.http.routers.<name>.<subkey…>` label. Used by
+// extractLabelName to detect when a user has accidentally put dots inside the
+// router name itself (which would be ambiguous to parse). Keep this in sync
+// with applyRouterOptions / handleRouterTLS.
+var routerSubkeyAllowList = map[string]bool{
+	"rule":        true,
+	"entrypoints": true,
+	"entrypoint":  true, // backward-compat singular form
+	"middlewares": true,
+	"priority":    true,
+	"service":     true,
+	"tls":         true,
+}
+
+// serviceSubkeyAllowList is the equivalent for `traefik.http.services.<name>.<subkey…>`.
+// Today only `loadbalancer` exists as a top-level subkey under a service.
+var serviceSubkeyAllowList = map[string]bool{
+	"loadbalancer": true,
+}
+
+// extractLabelName parses a label key of the form `<prefix><name>.<subkey…>`
+// and returns the name. It returns ok=false when:
+//   - the key does not start with the prefix
+//   - the key has no subkey portion at all
+//   - the first dot-segment of the subkey is not in `allow` (which strongly
+//     suggests the user put dots in the name itself; we cannot disambiguate
+//     "router named my.app with sub-key rule" from "router named my with
+//     sub-key app.rule" without a complete subkey registry)
+//
+// Callers that get ok=false should log a warning and skip the label.
+func extractLabelName(key, prefix string, allow map[string]bool) (string, bool) {
+	rest := strings.TrimPrefix(key, prefix)
+	if rest == key {
+		return "", false
+	}
+	parts := strings.SplitN(rest, ".", 2)
+	if len(parts) < 2 || parts[0] == "" {
+		return "", false
+	}
+	name, subkey := parts[0], parts[1]
+	// First dot-segment of the subkey (e.g. "tls" from "tls.options").
+	firstSub := subkey
+	if i := strings.Index(firstSub, "."); i >= 0 {
+		firstSub = firstSub[:i]
+	}
+	// Strip array indexer like `domains[0]` so we compare the bare token.
+	if i := strings.Index(firstSub, "["); i >= 0 {
+		firstSub = firstSub[:i]
+	}
+	if !allow[firstSub] {
+		return "", false
+	}
+	return name, true
+}
+
 // Handle TLS configuration
 func handleRouterTLS(service internal.Service, prefix string) *dynamic.RouterTLSConfig {
 	tlsEnabled := false
@@ -537,10 +689,9 @@ func handleRouterTLS(service internal.Service, prefix string) *dynamic.RouterTLS
 	options, hasOptions := service.Config[prefix+".tls.options"]
 
 	// Check for array-indexed domains: tls.domains[N].main/sans
-	domainPattern := regexp.MustCompile(`\.tls\.domains\[(\d+)\]\.(main|sans)$`)
 	domainMap := make(map[int]*types.Domain)
 	for key, value := range service.Config {
-		if matches := domainPattern.FindStringSubmatch(key); matches != nil {
+		if matches := tlsDomainPattern.FindStringSubmatch(key); matches != nil {
 			idx, _ := strconv.Atoi(matches[1])
 			if domainMap[idx] == nil {
 				domainMap[idx] = &types.Domain{}
@@ -587,18 +738,26 @@ func handleRouterTLS(service internal.Service, prefix string) *dynamic.RouterTLS
 	return tlsConfig
 }
 
-// Helper to get service URL with correct port
-func getServiceURL(service internal.Service, serviceName string, nodeName string) string {
+// getServiceURLs builds the list of backend URLs for a service. Each entry
+// becomes one Server in the load balancer. Precedence (first match wins,
+// returning a single-element slice):
+//  1. Explicit `…server.url` label
+//  2. Explicit `…server.ip` label (combined with port + scheme)
+//  3. Discovered guest-agent IPs (one URL per IP, sorted by address for
+//     deterministic output across polls)
+//  4. Hostname fallback `<vmname>.<nodename>:<port>` (logged at debug only;
+//     usually means the guest agent isn't reporting IPs)
+func getServiceURLs(service internal.Service, serviceName string, nodeName string, debug bool) []string {
 	// Check for direct URL override
 	urlLabel := fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.url", serviceName)
 	if url, exists := service.Config[urlLabel]; exists {
-		return url
+		return []string{url}
 	}
 
 	// Default protocol and port
 	protocol := "http"
 	port := "80"
-	
+
 	// Check for HTTPS protocol setting
 	httpsLabel := fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.scheme", serviceName)
 	if scheme, exists := service.Config[httpsLabel]; exists && scheme == "https" {
@@ -606,7 +765,7 @@ func getServiceURL(service internal.Service, serviceName string, nodeName string
 		// Update default port for HTTPS
 		port = "443"
 	}
-	
+
 	// Look for service-specific port
 	portLabel := fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.port", serviceName)
 	if val, exists := service.Config[portLabel]; exists {
@@ -616,23 +775,31 @@ func getServiceURL(service internal.Service, serviceName string, nodeName string
 	// Look for service-specific ip
 	ipLabel := fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.ip", serviceName)
 	if val, exists := service.Config[ipLabel]; exists {
-		return fmt.Sprintf("%s://%s:%s", protocol, val, port)
+		return []string{fmt.Sprintf("%s://%s:%s", protocol, val, port)}
 	}
-	
-	// Use IP if available, otherwise fall back to hostname
+
+	// Use guest-agent IPs if available, otherwise fall back to hostname.
 	if len(service.IPs) > 0 {
-		// Create a list of server URLs from all IPs
+		urls := make([]string, 0, len(service.IPs))
 		for _, ip := range service.IPs {
 			if ip.Address != "" {
-				return fmt.Sprintf("%s://%s:%s", protocol, ip.Address, port)
+				urls = append(urls, fmt.Sprintf("%s://%s:%s", protocol, ip.Address, port))
 			}
 		}
+		if len(urls) > 0 {
+			// Sort so the emitted load-balancer config is stable across polls
+			// even if the guest agent reorders interfaces.
+			sort.Strings(urls)
+			return urls
+		}
 	}
-	
+
 	// Fall back to hostname
 	url := fmt.Sprintf("%s://%s.%s:%s", protocol, service.Name, nodeName, port)
-	log.Printf("No IPs found, using hostname URL %s for service %s (ID: %d)", url, service.Name, service.ID)
-	return url
+	if debug {
+		log.Printf("No IPs found, using hostname URL %s for service %s (ID: %d)", url, service.Name, service.ID)
+	}
+	return []string{url}
 }
 
 // Helper to get router rule
@@ -670,12 +837,16 @@ func stringToBool(s string) (bool, error) {
 	}
 }
 
-// Helper to convert map keys to slice
+// mapKeysToSlice returns the keys of m as a slice in deterministic
+// (lexicographic) order. Sorting matters because callers iterate the result
+// to build router/service configuration; without it, downstream behavior
+// (e.g. which service a router defaults to) flaps between polls.
 func mapKeysToSlice(m map[string]bool) []string {
 	result := make([]string, 0, len(m))
 	for k := range m {
 		result = append(result, k)
 	}
+	sort.Strings(result)
 	return result
 }
 
@@ -708,7 +879,17 @@ func validateConfig(config *Config) error {
 	return nil
 }
 
+// isBoolLabelEnabled returns true when `label` is present in `labels` and its
+// value parses as a Go bool via strconv.ParseBool. This matches Traefik's own
+// Docker provider semantics — accepts "1", "t", "T", "true", "True", "TRUE"
+// (and "false", "0", "f" etc. as false). It intentionally does NOT use the
+// more permissive stringToBool helper, which accepts "yes"/"on"/"off" — those
+// are not recognized by Traefik core.
 func isBoolLabelEnabled(labels map[string]string, label string) bool {
 	val, exists := labels[label]
-	return exists && val == "true"
+	if !exists {
+		return false
+	}
+	b, err := strconv.ParseBool(val)
+	return err == nil && b
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/NX211/traefik-proxmox-provider/internal"
+	"github.com/traefik/genconf/dynamic"
 )
 
 func TestProviderConfig(t *testing.T) {
@@ -241,26 +242,26 @@ func TestProviderService(t *testing.T) {
 	}
 }
 
-func TestGetServiceURL(t *testing.T) {
+func TestGetServiceURLs(t *testing.T) {
 	tests := []struct {
-		name        string
-		service     internal.Service
-		serviceName string
-		nodeName    string
-		expectedUrl string
+		name         string
+		service      internal.Service
+		serviceName  string
+		nodeName     string
+		expectedURLs []string
 	}{
 		{
-			name:        "IP set, default port and scheme",
+			name:        "IP label set, default port and scheme",
 			serviceName: "service",
 			service: internal.Service{
 				Config: map[string]string{
 					"traefik.http.services.service.loadbalancer.server.ip": "1.2.3.4",
 				},
 			},
-			expectedUrl: "http://1.2.3.4:80",
+			expectedURLs: []string{"http://1.2.3.4:80"},
 		},
 		{
-			name:        "IP and scheme set, default port (http)",
+			name:        "IP label and scheme=http set",
 			serviceName: "service",
 			service: internal.Service{
 				Config: map[string]string{
@@ -268,10 +269,10 @@ func TestGetServiceURL(t *testing.T) {
 					"traefik.http.services.service.loadbalancer.server.scheme": "http",
 				},
 			},
-			expectedUrl: "http://1.2.3.4:80",
+			expectedURLs: []string{"http://1.2.3.4:80"},
 		},
 		{
-			name:        "IP and scheme set, default port (https)",
+			name:        "IP label and scheme=https set, default port",
 			serviceName: "service",
 			service: internal.Service{
 				Config: map[string]string{
@@ -279,10 +280,10 @@ func TestGetServiceURL(t *testing.T) {
 					"traefik.http.services.service.loadbalancer.server.scheme": "https",
 				},
 			},
-			expectedUrl: "https://1.2.3.4:443",
+			expectedURLs: []string{"https://1.2.3.4:443"},
 		},
 		{
-			name:        "IP, port and scheme set",
+			name:        "IP label, port and scheme set",
 			serviceName: "service",
 			service: internal.Service{
 				Config: map[string]string{
@@ -291,20 +292,20 @@ func TestGetServiceURL(t *testing.T) {
 					"traefik.http.services.service.loadbalancer.server.port":   "8080",
 				},
 			},
-			expectedUrl: "https://1.2.3.4:8080",
+			expectedURLs: []string{"https://1.2.3.4:8080"},
 		},
 		{
-			name:        "URL is set",
+			name:        "URL label set",
 			serviceName: "service",
 			service: internal.Service{
 				Config: map[string]string{
 					"traefik.http.services.service.loadbalancer.server.url": "http://test.com:1234",
 				},
 			},
-			expectedUrl: "http://test.com:1234",
+			expectedURLs: []string{"http://test.com:1234"},
 		},
 		{
-			name:        "URL overrides other settings",
+			name:        "URL label overrides everything else",
 			serviceName: "service",
 			service: internal.Service{
 				Config: map[string]string{
@@ -314,15 +315,57 @@ func TestGetServiceURL(t *testing.T) {
 					"traefik.http.services.service.loadbalancer.server.port":   "8080",
 				},
 			},
-			expectedUrl: "http://test.com:1234",
+			expectedURLs: []string{"http://test.com:1234"},
+		},
+		{
+			name:        "single discovered IP",
+			serviceName: "service",
+			service: internal.Service{
+				Config: map[string]string{},
+				IPs: []internal.IP{
+					{Address: "10.0.0.5", AddressType: "ipv4"},
+				},
+			},
+			expectedURLs: []string{"http://10.0.0.5:80"},
+		},
+		{
+			name:        "multiple discovered IPs fan out and sort",
+			serviceName: "service",
+			service: internal.Service{
+				Config: map[string]string{
+					"traefik.http.services.service.loadbalancer.server.port": "8080",
+				},
+				// Deliberately reversed to verify sorting kicks in.
+				IPs: []internal.IP{
+					{Address: "192.168.1.20", AddressType: "ipv4"},
+					{Address: "10.0.0.5", AddressType: "ipv4"},
+				},
+			},
+			expectedURLs: []string{"http://10.0.0.5:8080", "http://192.168.1.20:8080"},
+		},
+		{
+			name:        "hostname fallback when no IPs",
+			serviceName: "service",
+			service: internal.Service{
+				ID:     42,
+				Name:   "myvm",
+				Config: map[string]string{},
+			},
+			nodeName:     "pve1",
+			expectedURLs: []string{"http://myvm.pve1:80"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := getServiceURL(tt.service, tt.serviceName, tt.nodeName)
-			if url != tt.expectedUrl {
-				t.Errorf("Expected URL to be %s, got %s", tt.expectedUrl, url)
+			urls := getServiceURLs(tt.service, tt.serviceName, tt.nodeName, false)
+			if len(urls) != len(tt.expectedURLs) {
+				t.Fatalf("len(urls) = %d, want %d. Got %v", len(urls), len(tt.expectedURLs), urls)
+			}
+			for i, want := range tt.expectedURLs {
+				if urls[i] != want {
+					t.Errorf("urls[%d] = %q, want %q", i, urls[i], want)
+				}
 			}
 		})
 	}
@@ -390,6 +433,379 @@ func TestHandleRouterTLS_ArrayDomains(t *testing.T) {
 						t.Errorf("Domain[%d].SANs length = %d, want %d", i, len(domain.SANs), len(tt.expectedSANs[i]))
 					}
 				}
+			}
+		})
+	}
+}
+
+// makeServiceMap is a tiny helper for generateConfiguration table tests.
+func makeServiceMap(node string, services ...internal.Service) map[string][]internal.Service {
+	return map[string][]internal.Service{node: services}
+}
+
+func TestGenerateConfiguration_DefaultIDNamespacing(t *testing.T) {
+	// VMID 101, name "web", only `enable=true` — no router/service labels.
+	// Expect a single router and service both keyed "web-101" (defaultID).
+	svc := internal.Service{
+		ID:   101,
+		Name: "web",
+		Config: map[string]string{
+			"traefik.enable": "true",
+		},
+	}
+	cfg := generateConfiguration(makeServiceMap("pve1", svc), false)
+
+	if _, ok := cfg.HTTP.Routers["web-101"]; !ok {
+		t.Errorf("Routers[web-101] missing. Got keys: %v", routerKeys(cfg))
+	}
+	if _, ok := cfg.HTTP.Services["web-101"]; !ok {
+		t.Errorf("Services[web-101] missing. Got keys: %v", serviceKeys(cfg))
+	}
+	// Default rule is Host(`<name>`)
+	if got := cfg.HTTP.Routers["web-101"].Rule; got != "Host(`web`)" {
+		t.Errorf("Rule = %q, want Host(`web`)", got)
+	}
+	// Default Service link points at the same defaultID (no extra suffix).
+	if got := cfg.HTTP.Routers["web-101"].Service; got != "web-101" {
+		t.Errorf("Service = %q, want web-101", got)
+	}
+	// Priority must NOT be hardcoded — Traefik default sort relies on 0.
+	if got := cfg.HTTP.Routers["web-101"].Priority; got != 0 {
+		t.Errorf("Priority = %d, want 0 (omitempty so Traefik default applies)", got)
+	}
+}
+
+func TestGenerateConfiguration_LabelNamespacing(t *testing.T) {
+	// User-supplied `app` router and service on VMID 101 must be emitted as `app-101`.
+	svc := internal.Service{
+		ID:   101,
+		Name: "web",
+		Config: map[string]string{
+			"traefik.enable":                                          "true",
+			"traefik.http.routers.app.rule":                           "Host(`app.example.com`)",
+			"traefik.http.services.app.loadbalancer.server.port":      "8080",
+		},
+	}
+	cfg := generateConfiguration(makeServiceMap("pve1", svc), false)
+
+	if _, ok := cfg.HTTP.Routers["app-101"]; !ok {
+		t.Fatalf("Routers[app-101] missing. Got: %v", routerKeys(cfg))
+	}
+	if _, ok := cfg.HTTP.Services["app-101"]; !ok {
+		t.Fatalf("Services[app-101] missing. Got: %v", serviceKeys(cfg))
+	}
+	// Bare "app" must NOT exist.
+	if _, ok := cfg.HTTP.Routers["app"]; ok {
+		t.Errorf("Routers[app] should not exist after namespacing")
+	}
+	// Default cross-link points at the namespaced service.
+	if got := cfg.HTTP.Routers["app-101"].Service; got != "app-101" {
+		t.Errorf("Service link = %q, want app-101", got)
+	}
+}
+
+func TestGenerateConfiguration_CrossReferenceRewrite(t *testing.T) {
+	// Router r1 explicitly references service svc1 on the same guest.
+	// After namespacing, r1 should point at svc1-200, not svc1.
+	svc := internal.Service{
+		ID:   200,
+		Name: "host",
+		Config: map[string]string{
+			"traefik.enable":                                       "true",
+			"traefik.http.routers.r1.rule":                         "Host(`r1.example.com`)",
+			"traefik.http.routers.r1.service":                      "svc1",
+			"traefik.http.services.svc1.loadbalancer.server.port":  "8080",
+		},
+	}
+	cfg := generateConfiguration(makeServiceMap("pve1", svc), false)
+
+	r, ok := cfg.HTTP.Routers["r1-200"]
+	if !ok {
+		t.Fatalf("Routers[r1-200] missing")
+	}
+	if r.Service != "svc1-200" {
+		t.Errorf("r1-200.Service = %q, want svc1-200", r.Service)
+	}
+}
+
+func TestGenerateConfiguration_PreservesForeignServiceRef(t *testing.T) {
+	// Router r1 references a service that is NOT declared on this guest.
+	// Such references (typically `name@file` from the file provider) must
+	// pass through unchanged.
+	svc := internal.Service{
+		ID:   101,
+		Name: "host",
+		Config: map[string]string{
+			"traefik.enable":                  "true",
+			"traefik.http.routers.r1.rule":    "Host(`r1.example.com`)",
+			"traefik.http.routers.r1.service": "external@file",
+		},
+	}
+	cfg := generateConfiguration(makeServiceMap("pve1", svc), false)
+
+	r, ok := cfg.HTTP.Routers["r1-101"]
+	if !ok {
+		t.Fatalf("Routers[r1-101] missing")
+	}
+	if r.Service != "external@file" {
+		t.Errorf("Service = %q, want external@file (foreign refs must not be rewritten)", r.Service)
+	}
+}
+
+func TestGenerateConfiguration_NoCollisionAcrossGuests(t *testing.T) {
+	// Two guests, both declaring router/service "app". Without namespacing
+	// they collide and the second wins silently. With namespacing both
+	// must be present and distinct.
+	svc100 := internal.Service{
+		ID:   100,
+		Name: "g1",
+		Config: map[string]string{
+			"traefik.enable":                                     "true",
+			"traefik.http.routers.app.rule":                      "Host(`a.example.com`)",
+			"traefik.http.services.app.loadbalancer.server.port": "8080",
+		},
+	}
+	svc200 := internal.Service{
+		ID:   200,
+		Name: "g2",
+		Config: map[string]string{
+			"traefik.enable":                                     "true",
+			"traefik.http.routers.app.rule":                      "Host(`b.example.com`)",
+			"traefik.http.services.app.loadbalancer.server.port": "9090",
+		},
+	}
+	cfg := generateConfiguration(makeServiceMap("pve1", svc100, svc200), false)
+
+	for _, key := range []string{"app-100", "app-200"} {
+		if _, ok := cfg.HTTP.Routers[key]; !ok {
+			t.Errorf("Routers[%s] missing", key)
+		}
+		if _, ok := cfg.HTTP.Services[key]; !ok {
+			t.Errorf("Services[%s] missing", key)
+		}
+	}
+	if got := cfg.HTTP.Routers["app-100"].Rule; got != "Host(`a.example.com`)" {
+		t.Errorf("app-100.Rule = %q, want Host(`a.example.com`)", got)
+	}
+	if got := cfg.HTTP.Routers["app-200"].Rule; got != "Host(`b.example.com`)" {
+		t.Errorf("app-200.Rule = %q, want Host(`b.example.com`)", got)
+	}
+}
+
+func TestGenerateConfiguration_DottedNameSkipped(t *testing.T) {
+	// `routers.my.app.rule` is ambiguous and must be rejected. The guest
+	// has no other router labels, so it falls back to the defaultID path.
+	svc := internal.Service{
+		ID:   50,
+		Name: "host",
+		Config: map[string]string{
+			"traefik.enable":                  "true",
+			"traefik.http.routers.my.app.rule": "Host(`a.example.com`)",
+		},
+	}
+	cfg := generateConfiguration(makeServiceMap("pve1", svc), false)
+
+	// No router named my.app, my-50, or my.app-50 should exist.
+	for _, k := range []string{"my", "my-50", "my.app", "my.app-50"} {
+		if _, ok := cfg.HTTP.Routers[k]; ok {
+			t.Errorf("Routers[%s] exists; dotted-name labels should be skipped entirely. Got keys %v", k, routerKeys(cfg))
+		}
+	}
+	// Default-ID router should exist (host-50) since no valid labels were
+	// extracted but traefik.enable=true.
+	if _, ok := cfg.HTTP.Routers["host-50"]; !ok {
+		t.Errorf("Routers[host-50] (defaultID) missing. Got %v", routerKeys(cfg))
+	}
+}
+
+func TestGenerateConfiguration_MultiIPFanout(t *testing.T) {
+	svc := internal.Service{
+		ID:   101,
+		Name: "web",
+		Config: map[string]string{
+			"traefik.enable":                                     "true",
+			"traefik.http.routers.app.rule":                      "Host(`app.example.com`)",
+			"traefik.http.services.app.loadbalancer.server.port": "8080",
+		},
+		IPs: []internal.IP{
+			{Address: "192.168.1.20", AddressType: "ipv4"},
+			{Address: "10.0.0.5", AddressType: "ipv4"},
+		},
+	}
+	cfg := generateConfiguration(makeServiceMap("pve1", svc), false)
+
+	servers := cfg.HTTP.Services["app-101"].LoadBalancer.Servers
+	if len(servers) != 2 {
+		t.Fatalf("len(Servers) = %d, want 2 (multi-IP fanout)", len(servers))
+	}
+	// Sorted lexicographically by URL.
+	want := []string{"http://10.0.0.5:8080", "http://192.168.1.20:8080"}
+	for i, w := range want {
+		if servers[i].URL != w {
+			t.Errorf("Servers[%d].URL = %q, want %q", i, servers[i].URL, w)
+		}
+	}
+}
+
+// routerKeys / serviceKeys collect map keys for assertion error messages.
+func routerKeys(cfg interface{ /* dynamic.Configuration */
+}) []string {
+	c := cfg.(*dynamic.Configuration)
+	out := make([]string, 0, len(c.HTTP.Routers))
+	for k := range c.HTTP.Routers {
+		out = append(out, k)
+	}
+	return out
+}
+
+func serviceKeys(cfg interface{ /* dynamic.Configuration */
+}) []string {
+	c := cfg.(*dynamic.Configuration)
+	out := make([]string, 0, len(c.HTTP.Services))
+	for k := range c.HTTP.Services {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestExtractLabelName(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		prefix  string
+		allow   map[string]bool
+		want    string
+		wantOk  bool
+	}{
+		{"router rule", "traefik.http.routers.r1.rule", "traefik.http.routers.", routerSubkeyAllowList, "r1", true},
+		{"router tls.options", "traefik.http.routers.r1.tls.options", "traefik.http.routers.", routerSubkeyAllowList, "r1", true},
+		{"router tls.domains[0].main", "traefik.http.routers.r1.tls.domains[0].main", "traefik.http.routers.", routerSubkeyAllowList, "r1", true},
+		{"router named tls", "traefik.http.routers.tls.rule", "traefik.http.routers.", routerSubkeyAllowList, "tls", true},
+		{"router named priority", "traefik.http.routers.priority.rule", "traefik.http.routers.", routerSubkeyAllowList, "priority", true},
+		{"dotted router name", "traefik.http.routers.my.app.rule", "traefik.http.routers.", routerSubkeyAllowList, "", false},
+		{"dotted router name two", "traefik.http.routers.api.v2.middlewares", "traefik.http.routers.", routerSubkeyAllowList, "", false},
+		{"router no subkey", "traefik.http.routers.r1", "traefik.http.routers.", routerSubkeyAllowList, "", false},
+		{"router empty name", "traefik.http.routers..rule", "traefik.http.routers.", routerSubkeyAllowList, "", false},
+		{"unknown prefix", "traefik.http.middlewares.m1.headers", "traefik.http.routers.", routerSubkeyAllowList, "", false},
+
+		{"service loadbalancer.server.port", "traefik.http.services.svc1.loadbalancer.server.port", "traefik.http.services.", serviceSubkeyAllowList, "svc1", true},
+		{"dotted service name", "traefik.http.services.my.svc.loadbalancer.server.port", "traefik.http.services.", serviceSubkeyAllowList, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := extractLabelName(tt.key, tt.prefix, tt.allow)
+			if ok != tt.wantOk {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOk)
+			}
+			if got != tt.want {
+				t.Errorf("name = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyRouterOptions(t *testing.T) {
+	t.Run("entrypoints plural", func(t *testing.T) {
+		svc := internal.Service{Config: map[string]string{
+			"traefik.http.routers.r1.entrypoints": "web,websecure",
+		}}
+		var r dynamic.Router
+		applyRouterOptions(&r, svc, "r1")
+		if len(r.EntryPoints) != 2 || r.EntryPoints[0] != "web" || r.EntryPoints[1] != "websecure" {
+			t.Errorf("EntryPoints = %v, want [web websecure]", r.EntryPoints)
+		}
+	})
+	t.Run("entrypoint singular", func(t *testing.T) {
+		svc := internal.Service{Config: map[string]string{
+			"traefik.http.routers.r1.entrypoint": "web",
+		}}
+		var r dynamic.Router
+		applyRouterOptions(&r, svc, "r1")
+		if len(r.EntryPoints) != 1 || r.EntryPoints[0] != "web" {
+			t.Errorf("EntryPoints = %v, want [web]", r.EntryPoints)
+		}
+	})
+	t.Run("middlewares", func(t *testing.T) {
+		svc := internal.Service{Config: map[string]string{
+			"traefik.http.routers.r1.middlewares": "auth@file,compression",
+		}}
+		var r dynamic.Router
+		applyRouterOptions(&r, svc, "r1")
+		if len(r.Middlewares) != 2 || r.Middlewares[0] != "auth@file" || r.Middlewares[1] != "compression" {
+			t.Errorf("Middlewares = %v, want [auth@file compression]", r.Middlewares)
+		}
+	})
+	t.Run("priority valid int", func(t *testing.T) {
+		svc := internal.Service{Config: map[string]string{
+			"traefik.http.routers.r1.priority": "42",
+		}}
+		var r dynamic.Router
+		applyRouterOptions(&r, svc, "r1")
+		if r.Priority != 42 {
+			t.Errorf("Priority = %d, want 42", r.Priority)
+		}
+	})
+	t.Run("priority invalid leaves zero", func(t *testing.T) {
+		svc := internal.Service{Config: map[string]string{
+			"traefik.http.routers.r1.priority": "notanint",
+		}}
+		var r dynamic.Router
+		applyRouterOptions(&r, svc, "r1")
+		if r.Priority != 0 {
+			t.Errorf("Priority = %d, want 0 (parse failure must leave zero)", r.Priority)
+		}
+	})
+	t.Run("no priority label leaves zero", func(t *testing.T) {
+		svc := internal.Service{Config: map[string]string{}}
+		var r dynamic.Router
+		applyRouterOptions(&r, svc, "r1")
+		if r.Priority != 0 {
+			t.Errorf("Priority = %d, want 0 (no label)", r.Priority)
+		}
+	})
+}
+
+func TestMapKeysToSlice_Sorted(t *testing.T) {
+	in := map[string]bool{"charlie": true, "alpha": true, "bravo": true, "delta": true}
+	got := mapKeysToSlice(in)
+	want := []string{"alpha", "bravo", "charlie", "delta"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("got[%d] = %q, want %q (full got = %v)", i, got[i], v, got)
+		}
+	}
+}
+
+func TestIsBoolLabelEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{"missing key", map[string]string{}, false},
+		{"empty value", map[string]string{"traefik.enable": ""}, false},
+		{"true literal", map[string]string{"traefik.enable": "true"}, true},
+		{"True mixed case", map[string]string{"traefik.enable": "True"}, true},
+		{"TRUE upper", map[string]string{"traefik.enable": "TRUE"}, true},
+		{"t shorthand", map[string]string{"traefik.enable": "t"}, true},
+		{"T shorthand", map[string]string{"traefik.enable": "T"}, true},
+		{"1 numeric", map[string]string{"traefik.enable": "1"}, true},
+		{"false literal", map[string]string{"traefik.enable": "false"}, false},
+		{"0 numeric", map[string]string{"traefik.enable": "0"}, false},
+		{"f shorthand", map[string]string{"traefik.enable": "f"}, false},
+		// Intentionally NOT supported (Traefik core doesn't accept these):
+		{"yes rejected", map[string]string{"traefik.enable": "yes"}, false},
+		{"on rejected", map[string]string{"traefik.enable": "on"}, false},
+		{"junk rejected", map[string]string{"traefik.enable": "blarg"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBoolLabelEnabled(tt.labels, "traefik.enable")
+			if got != tt.want {
+				t.Errorf("isBoolLabelEnabled(%v) = %v, want %v", tt.labels, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #47.

Bundles 9 correctness fixes discovered while running the plugin in a homelab. See issue #47 for the full motivation and per-bug analysis. This PR is the implementation.

## Breaking change

**Router and service names emitted by this provider are now suffixed with `-<vmid>`.** A label like `traefik.http.routers.app.rule=…` on VMID 101 produces a router named `app-101` in the generated Traefik config (and `app-101@plugin-traefik-proxmox-provider` in the Traefik dashboard).

Migration: any external Traefik config that referenced these names by their bare form must be updated to the suffixed name. Routing behavior is otherwise unchanged.

This is the only behavior break in the PR. The other 8 fixes are pure bug fixes. Per the discussion in #47, I'm shipping option **(a)** — unconditional namespacing with a clear `CHANGELOG.md` entry. Happy to switch to a config-flag-gated variant if you prefer.

## Fixes

1. **Drop hardcoded `Priority: 1`** so Traefik's `omitempty` rule-length default sort applies (`provider.go`).
2. **`isBoolLabelEnabled` → `strconv.ParseBool`** — accepts `1`, `t`, `T`, `true`, `True`, `TRUE`. Matches Traefik core's Docker provider exactly. Intentionally does NOT accept `yes`/`on`.
3. **Hoist TLS-domain regex to package-level `var`** (`tlsDomainPattern`).
4. **Sort `mapKeysToSlice` output** — kills router→service binding nondeterminism.
5. **Auto-namespace router/service names by VMID** (the breaking change). Same-guest router→service cross-references via `routers.<r>.service=<svc>` are rewritten automatically; foreign references like `external@file` pass through unchanged.
6. **Filter offline Proxmox nodes** — `internal.NodeStatus` now models the `status` field; `getServiceMap` skips nodes that aren't `online`.
7. **Warn-and-skip dotted router/service names.** New `extractLabelName` helper plus `routerSubkeyAllowList` / `serviceSubkeyAllowList` package vars detect labels where the user's name accidentally contains dots and logs a warning instead of silently truncating.
8. **Multi-IP fanout: `getServiceURL` → `getServiceURLs []string`.** One `Server` per filtered IP, sorted lexicographically for stable output across polls. Existing precedence (URL label → IP label → discovered IPs → hostname fallback) preserved.
9. **Typed sentinel errors in `internal/client.go`** (`ErrUnauthorized`, `ErrForbidden`, `ErrBadRequest`, `ErrServerError`) wrapping non-2xx responses. New `maybeWarnForbidden` helper in `provider.go` emits a one-shot WARN per VMID hinting at the PVE 9 token role on 403, instead of the current opaque generic error.

Plus: routine per-cycle log lines (`Skipping service …`, `Created router and service for …`, `No IPs found, using hostname URL …`) are now gated behind the existing `apiLogging=debug` flag. Previously they spammed Traefik's ERR-wrapped log on every poll cycle. `generateConfiguration` and `getServiceURLs` now take a `debug bool` parameter sourced from `client.LogLevel == internal.LogLevelDebug`.

Also standardized scattered `client.LogLevel == "debug"` literals to use the existing `internal.LogLevelDebug` constant.

## Test coverage

Total provider+internal sub-cases went from ~30 to ~125. New tests:

**`provider/provider_test.go`:**
- `TestGenerateConfiguration_DefaultIDNamespacing`
- `TestGenerateConfiguration_LabelNamespacing`
- `TestGenerateConfiguration_CrossReferenceRewrite`
- `TestGenerateConfiguration_PreservesForeignServiceRef`
- `TestGenerateConfiguration_NoCollisionAcrossGuests`
- `TestGenerateConfiguration_DottedNameSkipped`
- `TestGenerateConfiguration_MultiIPFanout`
- `TestExtractLabelName` (12 sub-cases)
- `TestApplyRouterOptions` (6 sub-cases — entrypoints plural/singular, middlewares, priority valid/invalid/missing)
- `TestIsBoolLabelEnabled` (14 sub-cases)
- `TestMapKeysToSlice_Sorted`

**`provider/provider_test.go` modified:**
- `TestGetServiceURL` → `TestGetServiceURLs` (existing 6 cases preserved as single-element slices, plus new cases for multi-IP fanout, single-IP, and hostname fallback)

**`internal/service_test.go`:**
- `TestNodeStatus_JSONUnmarshal` (4 sub-cases)

**`internal/client_test.go` (new file):**
- `TestClientDo_StatusErrorsWrapSentinels` (5 sub-cases — 401/403/400/500/503)
- `TestClientDo_2xxNoSentinel`

## Test plan

- [x] `go test ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make yaegi_test` — passes (verifies Yaegi compatibility)
- [x] Smoke-tested against my Proxmox VE homelab via Traefik's `experimental.localPlugins`. Verified end-to-end:
  - Namespacing visible in Traefik dashboard as `<name>-<vmid>@plugin-traefik-proxmox-provider`
  - Multi-poll cycles stable, no config churn (Traefik logs `Skipping unchanged configuration` between polls)
  - Backend reachable via the routed Host with a valid Let's Encrypt cert
  - With `apiLogging=info`: log is silent on routine polls, only legitimate errors appear
  - No regressions vs `v0.8.1`

## Splitting

Happy to split this into multiple smaller PRs if you'd prefer to land the safe fixes first and discuss the namespacing change separately. Natural split:

- **PR A — trivial:** 1, 2, 3, 4, plus the logging gate
- **PR B — safety:** 6, 8, 9
- **PR C — breaking:** 5
- **PR D — diagnostic:** 7

Just say the word and I'll resubmit accordingly.

