### PR TITLE
Extend healthcheck config to support more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ traefik.http.routers.myapp.tls.options=tlsoptions@file
 traefik.http.services.myservice.loadbalancer.healthcheck.path=/health
 traefik.http.services.myservice.loadbalancer.healthcheck.interval=10s
 traefik.http.services.myservice.loadbalancer.healthcheck.timeout=5s
+traefik.http.services.myservice.loadbalancer.healthcheck.scheme=http
+traefik.http.services.myservice.loadbalancer.healthcheck.port=8088
+traefik.http.services.myservice.loadbalancer.healthcheck.followRedirects=true
+traefik.http.services.myservice.loadbalancer.healthcheck.method=GET
+
 ```
 
 #### Sticky Sessions

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -471,6 +471,7 @@ func applyServiceOptions(lb *dynamic.ServersLoadBalancer, service internal.Servi
 	}
 	
 	// Handle HealthCheck
+	// https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#health-check
 	if healthcheckPath, exists := service.Config[prefix+".healthcheck.path"]; exists {
 		hc := &dynamic.ServerHealthCheck{
 			Path: healthcheckPath,
@@ -484,6 +485,26 @@ func applyServiceOptions(lb *dynamic.ServersLoadBalancer, service internal.Servi
 			hc.Timeout = timeout
 		}
 		
+		if scheme, exists := service.Config[prefix+".healthcheck.scheme"]; exists {
+			hc.Scheme = scheme
+		}
+
+		if port, exists := service.Config[prefix+".healthcheck.port"]; exists {
+			if val, err := stringToInt(port); err == nil {
+				hc.Port = val
+			}
+		}
+
+		if followRedirects, exists := service.Config[prefix+".healthcheck.followredirects"]; exists {
+			if val, err := stringToBool(followRedirects); err == nil {
+				hc.FollowRedirects = &val
+			}
+		}
+
+		if method, exists := service.Config[prefix+".healthcheck.method"]; exists {
+			hc.Method = method
+		}
+
 		lb.HealthCheck = hc
 	}
 	


### PR DESCRIPTION
I have a use case where the healthcheck for a bespoke service may need to be on a separate HTTP port from the primary service's HTTPS port. The current provider does not support this state, because it doesn't parse in tags for all of the possible healthcheck parameters.

I took a look at the currently supported set of healthcheck parameters from [the Traefik docs](https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/load-balancing/service/#health-check), and added support for specifying most of the currently-unsupported parameters (`Scheme`, `Port`, `FollowRedirects`, and `Method`) in the same way as the existing supported parameters.

I did have to skip adding a few parameters that either aren't supported by the current version of the [traefik/genconf library](https://pkg.go.dev/github.com/traefik/genconf/dynamic@v0.5.2#ServerHealthCheck) or would require a bit of a deeper refactor (eg `Headers`, which aren't a single value, and would need to be their own set of map[string]string, which isn't trivial to represent in the current Config struct).