### PR TITLE
fix: resolve DHCP container IPs from inet/inet6

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -9,7 +9,8 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv" // Added import
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -233,7 +234,7 @@ func (c *ProxmoxClient) GetContainerNetworkInterfaces(ctx context.Context, nodeN
 	for _, iface := range response.Data {
 		var ips []IP
 		for _, ip := range iface.IPAddresses {
-			prefixUint, err := strconv.ParseUint(ip.Prefix.String(), 10, 64) // Changed to use strconv.ParseUint
+			prefixUint, err := strconv.ParseUint(ip.Prefix.String(), 10, 64)
 			if err != nil {
 				// Log error but continue, as some IPs might be valid
 				if c.LogLevel == LogLevelDebug {
@@ -248,6 +249,20 @@ func (c *ProxmoxClient) GetContainerNetworkInterfaces(ctx context.Context, nodeN
 			})
 		}
 
+		// when iface.IPAddresses is empty, we might infer IP from DHCP inet value
+		if len(ips) == 0 {
+			if c.LogLevel == LogLevelDebug {
+				log.Printf("DEBUG: No valid IPs found for '%s', trying inet values: %+v", iface.Name, []string{iface.Inet, iface.Inet6})
+			}
+
+			if ip := parseCIDR(iface.Inet); ip.Address != "" {
+				ips = append(ips, ip)
+			}
+			if ip6 := parseCIDR(iface.Inet6); ip6.Address != "" {
+				ips = append(ips, ip6)
+			}
+		}
+
 		result.Result = append(result.Result, struct {
 			IPAddresses []IP `json:"ip-addresses"`
 		}{
@@ -256,4 +271,30 @@ func (c *ProxmoxClient) GetContainerNetworkInterfaces(ctx context.Context, nodeN
 	}
 
 	return result, nil
+}
+
+func parseCIDR(cidr string) IP {
+	if cidr == "" {
+		return IP{}
+	}
+
+	parts := strings.Split(cidr, "/")
+	address := parts[0]
+	var prefix uint64
+	if len(parts) > 1 {
+		if p, err := strconv.ParseUint(parts[1], 10, 64); err == nil {
+			prefix = p
+		}
+	}
+
+	addressType := "ipv4"
+	if strings.Contains(address, ":") {
+		addressType = "ipv6"
+	}
+
+	return IP{
+		Address:     address,
+		AddressType: addressType,
+		Prefix:      prefix,
+	}
 }

--- a/internal/service_test.go
+++ b/internal/service_test.go
@@ -203,4 +203,49 @@ func TestParsedAgentInterfaces_GetIPs(t *testing.T) {
 	if ips[1].Address != "10.0.0.1" {
 		t.Errorf("Expected second IP to be 10.0.0.1, got %s", ips[1].Address)
 	}
-} 
+}
+
+func TestParseCIDR(t *testing.T) {
+	// parseCIDR turns a DHCP inet/inet6 CIDR string into an IP, used to infer
+	// container IPs when the guest agent reports no addresses.
+	tests := []struct {
+		name string
+		cidr string
+		want IP
+	}{
+		{
+			name: "ipv4 with prefix",
+			cidr: "8.8.8.8/24",
+			want: IP{Address: "8.8.8.8", AddressType: "ipv4", Prefix: 24},
+		},
+		{
+			name: "ipv6 with prefix",
+			cidr: "fe80::1/64",
+			want: IP{Address: "fe80::1", AddressType: "ipv6", Prefix: 64},
+		},
+		{
+			name: "address without prefix",
+			cidr: "10.0.0.5",
+			want: IP{Address: "10.0.0.5", AddressType: "ipv4", Prefix: 0},
+		},
+		{
+			name: "invalid prefix is ignored",
+			cidr: "10.0.0.5/notanumber",
+			want: IP{Address: "10.0.0.5", AddressType: "ipv4", Prefix: 0},
+		},
+		{
+			name: "empty string yields zero IP",
+			cidr: "",
+			want: IP{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCIDR(tt.cidr)
+			if got != tt.want {
+				t.Errorf("parseCIDR(%q) = %+v, want %+v", tt.cidr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
My DHCP containers never got an IP and it took me a bit to work out why.

The `/lxc/{id}/interfaces` call returns them with an empty `ip-addresses` array, but `inet`/`inet6` are still populated with the actual address. The code only looked at the array, so those containers fell back to the `<name>.<node>` hostname, which doesn't resolve on my network.

This reads `inet`/`inet6` when the array comes back empty. I pulled the CIDR handling into a small `parseCIDR` helper and added tests for it (v4, v6, missing prefix, garbage prefix, empty string).

Might be behind some of the hostname-fallback reports in #18, at least for DHCP guests. In my case it wasn't the permissions thing that comes up there: the agent was answering fine, it just doesn't put the address in the array.