### PR TITLE
feat: allow multiple routers per service

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -403,6 +403,12 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 				
 				// Find target service (prefer explicit mapping)
 				targetService := serviceNames[0]
+				for _, sn := range serviceNames {
+					if sn == routerName {
+						targetService = sn
+						break
+					}
+				}
 				serviceLabel := fmt.Sprintf("traefik.http.routers.%s.service", routerName)
 				if val, exists := service.Config[serviceLabel]; exists {
 					targetService = val

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -394,3 +394,38 @@ func TestHandleRouterTLS_ArrayDomains(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateConfiguration_MultipleRouters(t *testing.T) {
+	// A single service defining multiple routers and multiple services should
+	// wire each router to the service whose name matches the router, rather than
+	// pointing every router at the first service.
+	service := internal.Service{
+		ID:   100,
+		Name: "multi",
+		Config: map[string]string{
+			"traefik.enable":                                     "true",
+			"traefik.http.routers.blog.rule":                     "Host(`blog.example.com`)",
+			"traefik.http.routers.shop.rule":                     "Host(`shop.example.com`)",
+			"traefik.http.services.blog.loadbalancer.server.url": "http://23.45.67.89:8080",
+			"traefik.http.services.shop.loadbalancer.server.url": "http://23.45.67.90:8080",
+		},
+	}
+	servicesMap := map[string][]internal.Service{"node1": {service}}
+
+	config := generateConfiguration(servicesMap)
+
+	if len(config.HTTP.Routers) != 2 {
+		t.Fatalf("Expected 2 routers, got %d: %v", len(config.HTTP.Routers), config.HTTP.Routers)
+	}
+
+	for _, name := range []string{"blog", "shop"} {
+		router, exists := config.HTTP.Routers[name]
+		if !exists {
+			t.Errorf("Expected router %q to exist", name)
+			continue
+		}
+		if router.Service != name {
+			t.Errorf("Router %q should target service %q, got %q", name, name, router.Service)
+		}
+	}
+}


### PR DESCRIPTION
Ran into this on my own setup: when a container defines more than one router in its labels, only the first one actually worked. Every router got pointed at the first service in the map, so a second router on the same LXC ended up on the wrong backend without any error.

This walks each `traefik.http.routers.<name>` and binds it to the service whose name matches, instead of always taking `serviceNames[0]`. That lets one container front a couple of routers (say different hostnames or ports off the same box). I added a test with two routers and two services on one container, checking each router lands on its own service.

One thing worth flagging: this overlaps with #47 (the point about the nondeterministic `serviceNames[0]` binding) and @ksorokin's #48, which touches the same spot as part of a larger cleanup and goes with namespacing. Mine is a smaller change aimed at just that binding. I'm happy to defer to #48 or rework this if you'd prefer that direction. Putting it up mainly so you can compare the two approaches.