### PR TITLE
feat: support multiple standalone Proxmox endpoints

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -14,7 +14,7 @@ testData:
   apiLogging: "info"
   apiValidateSSL: "true"
 
-# Sample provider configuration
+# Sample provider configuration (single endpoint)
 providers:
   plugin:
     traefik-proxmox-provider:
@@ -24,3 +24,20 @@ providers:
       apiToken: "00000000-0000-0000-0000-000000000000"
       apiLogging: "debug"
       apiValidateSSL: "false"
+
+# Sample provider configuration (multiple standalone Proxmox hosts)
+# providers:
+#   plugin:
+#     traefik-proxmox-provider:
+#       pollInterval: "30s"
+#       nodes:
+#         - name: "pve1"
+#           apiEndpoint: "https://pve1.example.com:8006"
+#           apiTokenId: "root@pam!traefik"
+#           apiToken: "00000000-0000-0000-0000-000000000001"
+#           apiValidateSSL: "true"
+#         - name: "pve2"
+#           apiEndpoint: "https://pve2.example.com:8006"
+#           apiTokenId: "root@pam!traefik"
+#           apiToken: "00000000-0000-0000-0000-000000000002"
+#           apiValidateSSL: "false"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Multiple Proxmox endpoints in a single plugin instance via the `nodes` list, for VMs/containers spread across standalone (non-clustered) Proxmox hosts. Based on the approach from PR #43 by @jonmilele.
+- Auto-generated router/service IDs are prefixed with the endpoint `name` when multiple endpoints are configured, so identical VM names/IDs on different hosts don't collide.
+- Per-endpoint connection log: the Proxmox VE version and logical endpoint name are logged on the first successful poll of each endpoint.
+
+### Changed
+
+- An unreachable Proxmox endpoint no longer aborts provider startup. It is logged as a warning and retried on every poll, and a failing endpoint never affects routes discovered on the remaining endpoints. Structurally invalid configuration (missing endpoint/token fields) is still a fatal error, per entry.
+- When every configured endpoint is unreachable during a poll, the previous dynamic configuration is kept instead of pushing an empty one.
+
 ## [v0.7.0] - 2024-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,6 +53,46 @@ providers:
 | `apiToken` | `string` | - | The API token secret |
 | `apiLogging` | `string` | `"info"` | Log level for API operations ("debug" or "info") |
 | `apiValidateSSL` | `string` | `"true"` | Whether to validate SSL certificates |
+| `nodes` | `list` | - | Multiple Proxmox endpoints (see [Multiple Proxmox Endpoints](#multiple-proxmox-endpoints)) |
+
+### Multiple Proxmox Endpoints
+
+If your VMs and containers are spread across separate, standalone Proxmox installations (not joined in a cluster), a single `apiEndpoint` can only see one of them. The `nodes` list lets one plugin instance poll several Proxmox APIs and merge everything it finds into a single dynamic configuration.
+
+> **Note:** If your Proxmox nodes are part of the same cluster you don't need this — the plugin already discovers every node in a cluster through a single `apiEndpoint`.
+
+Each entry accepts the same fields as the flat single-endpoint config, plus a `name`:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `name` | `string` | `node-<index>` | Logical name for this endpoint, used in logs and to disambiguate auto-generated router/service IDs |
+| `apiEndpoint` | `string` | - | The URL of this Proxmox VE API |
+| `apiTokenId` | `string` | - | The API token ID for this endpoint |
+| `apiToken` | `string` | - | The API token secret for this endpoint |
+| `apiLogging` | `string` | `"info"` | Log level for this endpoint |
+| `apiValidateSSL` | `string` | `"true"` | Whether to validate SSL certificates for this endpoint |
+
+```yaml
+providers:
+  plugin:
+    traefik-proxmox-provider:
+      pollInterval: "30s"
+      nodes:
+        - name: "pve1"
+          apiEndpoint: "https://pve1.example.com:8006"
+          apiTokenId: "root@pam!traefik"
+          apiToken: "your-token-1"
+        - name: "pve2"
+          apiEndpoint: "https://pve2.example.com:8006"
+          apiTokenId: "root@pam!traefik"
+          apiToken: "your-token-2"
+```
+
+A few things worth knowing about this mode:
+
+- The flat single-endpoint config keeps working exactly as before. When `nodes` is present, the flat `apiEndpoint`/`apiTokenId`/`apiToken` fields are ignored.
+- An endpoint that is down does not stop the provider from starting, and it never affects the routes discovered on the other endpoints. Unreachable endpoints are logged as warnings and retried on every poll.
+- When a VM/container has `traefik.enable=true` but no explicit router/service names in its labels, the auto-generated fallback IDs are prefixed with the endpoint `name` (e.g. `pve1-myvm-100`) so identical VM names or IDs on different hosts can't collide. Explicit names from labels (e.g. `traefik.http.routers.myapp.rule=...`) are used as-is — keeping those unique across hosts is up to you.
 
 ## Proxmox API Token Setup
 

--- a/provider/multi_endpoint_test.go
+++ b/provider/multi_endpoint_test.go
@@ -1,0 +1,390 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NX211/traefik-proxmox-provider/internal"
+	"github.com/traefik/genconf/dynamic"
+)
+
+// newMockPVE spins up a fake Proxmox API serving a single node with a single
+// running VM labeled traefik.enable=true.
+func newMockPVE(t *testing.T, nodeName, release, vmName, vmIP string) *httptest.Server {
+	t.Helper()
+
+	writeJSON := func(w http.ResponseWriter, body string) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, body)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api2/json/version", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fmt.Sprintf(`{"data":{"release":"%s"}}`, release))
+	})
+	mux.HandleFunc("/api2/json/nodes", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fmt.Sprintf(`{"data":[{"node":"%s"}]}`, nodeName))
+	})
+	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/qemu", nodeName), func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fmt.Sprintf(`{"data":[{"vmid":100,"name":"%s","status":"running"}]}`, vmName))
+	})
+	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/lxc", nodeName), func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, `{"data":[]}`)
+	})
+	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/qemu/100/config", nodeName), func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, `{"data":{"description":"traefik.enable=true"}}`)
+	})
+	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/qemu/100/agent/network-get-interfaces", nodeName), func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fmt.Sprintf(`{"data":{"result":[{"ip-addresses":[{"ip-address":"%s","ip-address-type":"ipv4","prefix":24}]}]}}`, vmIP))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newTestClient(name, endpoint string) *namedClient {
+	return &namedClient{
+		name:   name,
+		client: internal.NewProxmoxClient(endpoint, "test@pam!test", "token", false, "info"),
+	}
+}
+
+func TestNormalizeNodes(t *testing.T) {
+	t.Run("legacy flat config wrapped as single node", func(t *testing.T) {
+		config := &Config{
+			PollInterval:   "5s",
+			ApiEndpoint:    "https://proxmox.example.com",
+			ApiTokenId:     "test@pam!test",
+			ApiToken:       "test-token",
+			ApiLogging:     "debug",
+			ApiValidateSSL: "false",
+		}
+		nodes := normalizeNodes(config)
+		if len(nodes) != 1 {
+			t.Fatalf("Expected 1 node, got %d", len(nodes))
+		}
+		if nodes[0].Name != "default" {
+			t.Errorf("Expected name 'default', got %s", nodes[0].Name)
+		}
+		if nodes[0].ApiEndpoint != "https://proxmox.example.com" {
+			t.Errorf("Expected endpoint from flat config, got %s", nodes[0].ApiEndpoint)
+		}
+		if nodes[0].ApiLogging != "debug" {
+			t.Errorf("Expected logging 'debug', got %s", nodes[0].ApiLogging)
+		}
+		if nodes[0].ApiValidateSSL != "false" {
+			t.Errorf("Expected SSL validation 'false', got %s", nodes[0].ApiValidateSSL)
+		}
+	})
+
+	t.Run("multi-node config returned as-is", func(t *testing.T) {
+		config := &Config{
+			PollInterval: "5s",
+			Nodes: []NodeConfig{
+				{Name: "proxmox", ApiEndpoint: "https://pve1.example.com", ApiTokenId: "a", ApiToken: "1"},
+				{Name: "minimox", ApiEndpoint: "https://pve2.example.com", ApiTokenId: "b", ApiToken: "2"},
+			},
+		}
+		nodes := normalizeNodes(config)
+		if len(nodes) != 2 {
+			t.Fatalf("Expected 2 nodes, got %d", len(nodes))
+		}
+		if nodes[0].Name != "proxmox" || nodes[1].Name != "minimox" {
+			t.Errorf("Expected names to be preserved, got %s and %s", nodes[0].Name, nodes[1].Name)
+		}
+	})
+
+	t.Run("defaults filled in for sparse entries", func(t *testing.T) {
+		config := &Config{
+			PollInterval: "5s",
+			Nodes: []NodeConfig{
+				{ApiEndpoint: "https://pve1.example.com", ApiTokenId: "a", ApiToken: "1"},
+			},
+		}
+		nodes := normalizeNodes(config)
+		if nodes[0].Name != "node-0" {
+			t.Errorf("Expected auto-generated name 'node-0', got %s", nodes[0].Name)
+		}
+		if nodes[0].ApiLogging != "info" {
+			t.Errorf("Expected default logging 'info', got %s", nodes[0].ApiLogging)
+		}
+		if nodes[0].ApiValidateSSL != "true" {
+			t.Errorf("Expected default SSL validation 'true', got %s", nodes[0].ApiValidateSSL)
+		}
+	})
+}
+
+func TestValidateConfigMultiNode(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name: "valid multi-node config",
+			config: &Config{
+				PollInterval: "5s",
+				Nodes: []NodeConfig{
+					{Name: "proxmox", ApiEndpoint: "https://pve1.example.com", ApiTokenId: "a", ApiToken: "1"},
+					{Name: "minimox", ApiEndpoint: "https://pve2.example.com", ApiTokenId: "b", ApiToken: "2"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "entry missing endpoint is fatal",
+			config: &Config{
+				PollInterval: "5s",
+				Nodes: []NodeConfig{
+					{Name: "proxmox", ApiEndpoint: "https://pve1.example.com", ApiTokenId: "a", ApiToken: "1"},
+					{Name: "minimox", ApiTokenId: "b", ApiToken: "2"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "entry missing token is fatal",
+			config: &Config{
+				PollInterval: "5s",
+				Nodes: []NodeConfig{
+					{Name: "proxmox", ApiEndpoint: "https://pve1.example.com", ApiTokenId: "a"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nodes take precedence over incomplete flat fields",
+			config: &Config{
+				PollInterval: "5s",
+				Nodes: []NodeConfig{
+					{Name: "proxmox", ApiEndpoint: "https://pve1.example.com", ApiTokenId: "a", ApiToken: "1"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewSurvivesUnreachableEndpoint(t *testing.T) {
+	live := newMockPVE(t, "pve1", "8.4", "web", "10.0.0.5")
+
+	config := &Config{
+		PollInterval: "5s",
+		Nodes: []NodeConfig{
+			{Name: "proxmox", ApiEndpoint: live.URL, ApiTokenId: "a", ApiToken: "1"},
+			// 127.0.0.1:1 refuses connections immediately
+			{Name: "minimox", ApiEndpoint: "http://127.0.0.1:1", ApiTokenId: "b", ApiToken: "2"},
+		},
+	}
+
+	p, err := New(context.Background(), config, "test-provider")
+	if err != nil {
+		t.Fatalf("New() should not fail when an endpoint is unreachable, got: %v", err)
+	}
+	if len(p.clients) != 2 {
+		t.Errorf("Expected 2 clients (down endpoint retried on next poll), got %d", len(p.clients))
+	}
+}
+
+func TestGetServiceMapsPartialFailure(t *testing.T) {
+	live := newMockPVE(t, "pve1", "8.4", "web", "10.0.0.5")
+
+	clients := []*namedClient{
+		newTestClient("proxmox", live.URL),
+		newTestClient("minimox", "http://127.0.0.1:1"),
+	}
+
+	maps := getServiceMaps(clients, context.Background())
+	if len(maps) != 1 {
+		t.Fatalf("Expected 1 cluster map (dead endpoint skipped), got %d", len(maps))
+	}
+	if maps[0].clusterName != "proxmox" {
+		t.Errorf("Expected surviving map to be 'proxmox', got %s", maps[0].clusterName)
+	}
+	if len(maps[0].services["pve1"]) != 1 {
+		t.Errorf("Expected 1 service discovered on pve1, got %d", len(maps[0].services["pve1"]))
+	}
+}
+
+func TestUpdateConfigurationPartialFailureKeepsOtherRoutes(t *testing.T) {
+	live := newMockPVE(t, "pve1", "8.4", "web", "10.0.0.5")
+
+	p := &Provider{
+		name: "test-provider",
+		clients: []*namedClient{
+			newTestClient("proxmox", live.URL),
+			newTestClient("minimox", "http://127.0.0.1:1"),
+		},
+	}
+
+	cfgChan := make(chan json.Marshaler, 1)
+	if err := p.updateConfiguration(context.Background(), cfgChan); err != nil {
+		t.Fatalf("updateConfiguration() should succeed with one endpoint down, got: %v", err)
+	}
+
+	payload := (<-cfgChan).(*dynamic.JSONPayload)
+	// Two configured endpoints -> auto-generated IDs are prefixed.
+	if _, ok := payload.HTTP.Routers["proxmox-web-100"]; !ok {
+		t.Errorf("Expected router 'proxmox-web-100' from live endpoint, got routers: %v", routerKeys(payload.Configuration))
+	}
+}
+
+func TestUpdateConfigurationAllEndpointsDown(t *testing.T) {
+	p := &Provider{
+		name: "test-provider",
+		clients: []*namedClient{
+			newTestClient("proxmox", "http://127.0.0.1:1"),
+			newTestClient("minimox", "http://127.0.0.1:1"),
+		},
+	}
+
+	cfgChan := make(chan json.Marshaler, 1)
+	err := p.updateConfiguration(context.Background(), cfgChan)
+	if err == nil {
+		t.Fatal("updateConfiguration() should fail when every endpoint is down (so the previous config is kept)")
+	}
+	select {
+	case <-cfgChan:
+		t.Error("No configuration should be pushed when every endpoint is down")
+	default:
+	}
+}
+
+func TestGenerateConfigurationMultiEndpointPrefixing(t *testing.T) {
+	// Same VM name and ID on two standalone endpoints must not collide.
+	clusterMaps := []clusterServiceMap{
+		{
+			clusterName: "proxmox",
+			services: map[string][]internal.Service{
+				"pve1": {{
+					ID:     100,
+					Name:   "web",
+					IPs:    []internal.IP{{Address: "10.0.0.5", AddressType: "ipv4"}},
+					Config: map[string]string{"traefik.enable": "true"},
+				}},
+			},
+		},
+		{
+			clusterName: "minimox",
+			services: map[string][]internal.Service{
+				"pve2": {{
+					ID:     100,
+					Name:   "web",
+					IPs:    []internal.IP{{Address: "10.0.1.5", AddressType: "ipv4"}},
+					Config: map[string]string{"traefik.enable": "true"},
+				}},
+			},
+		},
+	}
+
+	config := generateConfiguration(clusterMaps, true)
+
+	for _, id := range []string{"proxmox-web-100", "minimox-web-100"} {
+		if _, ok := config.HTTP.Routers[id]; !ok {
+			t.Errorf("Expected router %q, got: %v", id, routerKeys(config))
+		}
+		if _, ok := config.HTTP.Services[id]; !ok {
+			t.Errorf("Expected service %q", id)
+		}
+	}
+
+	svc1 := config.HTTP.Services["proxmox-web-100"]
+	svc2 := config.HTTP.Services["minimox-web-100"]
+	if svc1 == nil || svc2 == nil {
+		t.Fatal("Expected both services to exist")
+	}
+	if svc1.LoadBalancer.Servers[0].URL == svc2.LoadBalancer.Servers[0].URL {
+		t.Errorf("Services should point at different backends, both got %s", svc1.LoadBalancer.Servers[0].URL)
+	}
+}
+
+func TestGenerateConfigurationSingleEndpointNoPrefix(t *testing.T) {
+	clusterMaps := []clusterServiceMap{
+		{
+			clusterName: "default",
+			services: map[string][]internal.Service{
+				"pve1": {{
+					ID:     100,
+					Name:   "web",
+					IPs:    []internal.IP{{Address: "10.0.0.5", AddressType: "ipv4"}},
+					Config: map[string]string{"traefik.enable": "true"},
+				}},
+			},
+		},
+	}
+
+	config := generateConfiguration(clusterMaps, false)
+
+	if _, ok := config.HTTP.Routers["web-100"]; !ok {
+		t.Errorf("Auto-generated IDs must stay unprefixed in single-endpoint mode, got: %v", routerKeys(config))
+	}
+}
+
+func TestGenerateConfigurationExplicitNamesNeverPrefixed(t *testing.T) {
+	clusterMaps := []clusterServiceMap{
+		{
+			clusterName: "proxmox",
+			services: map[string][]internal.Service{
+				"pve1": {{
+					ID:   100,
+					Name: "web",
+					IPs:  []internal.IP{{Address: "10.0.0.5", AddressType: "ipv4"}},
+					Config: map[string]string{
+						"traefik.enable":                  "true",
+						"traefik.http.routers.myapp.rule": "Host(`myapp.example.com`)",
+					},
+				}},
+			},
+		},
+	}
+
+	config := generateConfiguration(clusterMaps, true)
+
+	if _, ok := config.HTTP.Routers["myapp"]; !ok {
+		t.Errorf("Explicit router names must not be prefixed, got: %v", routerKeys(config))
+	}
+}
+
+func TestMaybeLogVersion(t *testing.T) {
+	t.Run("marks endpoint logged on success", func(t *testing.T) {
+		live := newMockPVE(t, "pve1", "8.4", "web", "10.0.0.5")
+		nc := newTestClient("proxmox", live.URL)
+
+		maybeLogVersion(nc, context.Background())
+		if !nc.versionLogged {
+			t.Error("Expected versionLogged to be true after successful version fetch")
+		}
+	})
+
+	t.Run("keeps retrying while endpoint is down", func(t *testing.T) {
+		nc := newTestClient("minimox", "http://127.0.0.1:1")
+
+		maybeLogVersion(nc, context.Background())
+		if nc.versionLogged {
+			t.Error("Expected versionLogged to stay false when endpoint is unreachable")
+		}
+	})
+}
+
+// routerKeys is a test helper for readable error messages.
+func routerKeys(cfg *dynamic.Configuration) []string {
+	result := make([]string, 0, len(cfg.HTTP.Routers))
+	for k := range cfg.HTTP.Routers {
+		result = append(result, k)
+	}
+	return result
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,14 +19,25 @@ import (
 	"github.com/traefik/genconf/dynamic/types"
 )
 
-// Config the plugin configuration.
-type Config struct {
-	PollInterval   string `json:"pollInterval" yaml:"pollInterval" toml:"pollInterval"`
+// NodeConfig represents the configuration for a single Proxmox endpoint.
+type NodeConfig struct {
+	Name           string `json:"name" yaml:"name" toml:"name"`
 	ApiEndpoint    string `json:"apiEndpoint" yaml:"apiEndpoint" toml:"apiEndpoint"`
 	ApiTokenId     string `json:"apiTokenId" yaml:"apiTokenId" toml:"apiTokenId"`
 	ApiToken       string `json:"apiToken" yaml:"apiToken" toml:"apiToken"`
 	ApiLogging     string `json:"apiLogging" yaml:"apiLogging" toml:"apiLogging"`
 	ApiValidateSSL string `json:"apiValidateSSL" yaml:"apiValidateSSL" toml:"apiValidateSSL"`
+}
+
+// Config the plugin configuration.
+type Config struct {
+	PollInterval   string       `json:"pollInterval" yaml:"pollInterval" toml:"pollInterval"`
+	ApiEndpoint    string       `json:"apiEndpoint" yaml:"apiEndpoint" toml:"apiEndpoint"`
+	ApiTokenId     string       `json:"apiTokenId" yaml:"apiTokenId" toml:"apiTokenId"`
+	ApiToken       string       `json:"apiToken" yaml:"apiToken" toml:"apiToken"`
+	ApiLogging     string       `json:"apiLogging" yaml:"apiLogging" toml:"apiLogging"`
+	ApiValidateSSL string       `json:"apiValidateSSL" yaml:"apiValidateSSL" toml:"apiValidateSSL"`
+	Nodes          []NodeConfig `json:"nodes" yaml:"nodes" toml:"nodes"`
 }
 
 // CreateConfig creates the default plugin configuration.
@@ -38,12 +49,51 @@ func CreateConfig() *Config {
 	}
 }
 
+// namedClient associates a logical name with a Proxmox API client.
+type namedClient struct {
+	name          string
+	client        *internal.ProxmoxClient
+	versionLogged bool
+}
+
 // Provider a plugin.
 type Provider struct {
 	name         string
 	pollInterval time.Duration
-	client       *internal.ProxmoxClient
+	clients      []*namedClient
 	cancel       func()
+}
+
+// normalizeNodes converts the Config into a canonical []NodeConfig slice.
+// If Nodes is populated it is returned directly (with defaults filled in);
+// otherwise a single-element slice is synthesized from the legacy flat
+// fields for backward compatibility.
+func normalizeNodes(config *Config) []NodeConfig {
+	if len(config.Nodes) > 0 {
+		for i := range config.Nodes {
+			if config.Nodes[i].ApiLogging == "" {
+				config.Nodes[i].ApiLogging = "info"
+			}
+			if config.Nodes[i].ApiValidateSSL == "" {
+				config.Nodes[i].ApiValidateSSL = "true"
+			}
+			if config.Nodes[i].Name == "" {
+				config.Nodes[i].Name = fmt.Sprintf("node-%d", i)
+			}
+		}
+		return config.Nodes
+	}
+
+	return []NodeConfig{
+		{
+			Name:           "default",
+			ApiEndpoint:    config.ApiEndpoint,
+			ApiTokenId:     config.ApiTokenId,
+			ApiToken:       config.ApiToken,
+			ApiLogging:     config.ApiLogging,
+			ApiValidateSSL: config.ApiValidateSSL,
+		},
+	}
 }
 
 // New creates a new Provider plugin.
@@ -62,26 +112,34 @@ func New(ctx context.Context, config *Config, name string) (*Provider, error) {
 		return nil, fmt.Errorf("poll interval must be at least 5 seconds, got %v", pi)
 	}
 
-	pc, err := newParserConfig(
-		config.ApiEndpoint,
-		config.ApiTokenId,
-		config.ApiToken,
-		config.ApiLogging,
-		config.ApiValidateSSL == "true",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("invalid parser config: %w", err)
-	}
-	client := newClient(pc)
+	nodes := normalizeNodes(config)
+	clients := make([]*namedClient, 0, len(nodes))
 
-	if err := logVersion(client, ctx); err != nil {
-		return nil, fmt.Errorf("failed to get Proxmox version: %w", err)
+	for _, node := range nodes {
+		pc, err := newParserConfig(
+			node.ApiEndpoint,
+			node.ApiTokenId,
+			node.ApiToken,
+			node.ApiLogging,
+			node.ApiValidateSSL == "true",
+		)
+		if err != nil {
+			return nil, fmt.Errorf("invalid parser config for node %q: %w", node.Name, err)
+		}
+
+		// An unreachable endpoint is not fatal here: it is logged and retried
+		// on every poll, so one Proxmox host being down never prevents the
+		// provider (and the routes of the remaining hosts) from starting.
+		nc := &namedClient{name: node.Name, client: newClient(pc)}
+		maybeLogVersion(nc, ctx)
+
+		clients = append(clients, nc)
 	}
 
 	return &Provider{
 		name:         name,
 		pollInterval: pi,
-		client:       client,
+		clients:      clients,
 	}, nil
 }
 
@@ -130,12 +188,15 @@ func (p *Provider) loadConfiguration(ctx context.Context, cfgChan chan<- json.Ma
 }
 
 func (p *Provider) updateConfiguration(ctx context.Context, cfgChan chan<- json.Marshaler) error {
-	servicesMap, err := getServiceMap(p.client, ctx)
-	if err != nil {
-		return fmt.Errorf("error getting service map: %w", err)
+	clusterMaps := getServiceMaps(p.clients, ctx)
+
+	// If every endpoint failed, keep the previous configuration instead of
+	// pushing an empty one that would wipe all discovered routes.
+	if len(clusterMaps) == 0 && len(p.clients) > 0 {
+		return errors.New("all Proxmox endpoints are unreachable, keeping previous configuration")
 	}
 
-	configuration := generateConfiguration(servicesMap)
+	configuration := generateConfiguration(clusterMaps, len(p.clients) > 1)
 	cfgChan <- &dynamic.JSONPayload{Configuration: configuration}
 	return nil
 }
@@ -174,32 +235,76 @@ func newClient(pc ParserConfig) *internal.ProxmoxClient {
 	return internal.NewProxmoxClient(pc.ApiEndpoint, pc.TokenId, pc.Token, pc.ValidateSSL, pc.LogLevel)
 }
 
-func logVersion(client *internal.ProxmoxClient, ctx context.Context) error {
-	version, err := client.GetVersion(ctx)
-	if err != nil {
-		return err
+// maybeLogVersion logs the Proxmox version of an endpoint once, on the first
+// successful contact. Failures are warnings: the endpoint is retried on every
+// poll until it answers.
+func maybeLogVersion(nc *namedClient, ctx context.Context) {
+	if nc.versionLogged {
+		return
 	}
-	log.Printf("Connected to Proxmox VE version %s", version.Release)
-	return nil
+
+	version, err := nc.client.GetVersion(ctx)
+	if err != nil {
+		log.Printf("WARN: Proxmox endpoint %q is unreachable, will retry on next poll: %v", nc.name, err)
+		return
+	}
+
+	log.Printf("Connected to Proxmox VE version %s (endpoint %q)", version.Release, nc.name)
+	nc.versionLogged = true
 }
 
-func getServiceMap(client *internal.ProxmoxClient, ctx context.Context) (map[string][]internal.Service, error) {
+// clusterServiceMap holds the services discovered from a single Proxmox
+// endpoint, keyed by Proxmox node name, along with the logical name of the
+// endpoint.
+type clusterServiceMap struct {
+	clusterName string
+	services    map[string][]internal.Service
+}
+
+// getServiceMaps polls every configured endpoint. A failing endpoint is
+// logged and skipped so it never affects the services discovered by the
+// remaining endpoints.
+func getServiceMaps(clients []*namedClient, ctx context.Context) []clusterServiceMap {
+	results := make([]clusterServiceMap, 0, len(clients))
+
+	for i := 0; i < len(clients); i++ {
+		maybeLogVersion(clients[i], ctx)
+
+		csm, err := getServiceMapForClient(clients[i], ctx)
+		if err != nil {
+			log.Printf("Error scanning nodes for endpoint %q: %v", clients[i].name, err)
+			continue
+		}
+		results = append(results, csm)
+	}
+
+	return results
+}
+
+// getServiceMapForClient queries a single Proxmox endpoint. Extracted into
+// its own function to guarantee clean variable scoping under yaegi
+// (Traefik's Go interpreter).
+func getServiceMapForClient(nc *namedClient, ctx context.Context) (clusterServiceMap, error) {
 	servicesMap := make(map[string][]internal.Service)
 
-	nodes, err := client.GetNodes(ctx)
+	nodes, err := nc.client.GetNodes(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error scanning nodes: %w", err)
+		return clusterServiceMap{}, err
 	}
 
 	for _, nodeStatus := range nodes {
-		services, err := scanServices(client, ctx, nodeStatus.Node)
+		services, err := scanServices(nc.client, ctx, nodeStatus.Node)
 		if err != nil {
-			log.Printf("Error scanning services on node %s: %v", nodeStatus.Node, err)
+			log.Printf("Error scanning services on node %s (endpoint %q): %v", nodeStatus.Node, nc.name, err)
 			continue
 		}
 		servicesMap[nodeStatus.Node] = services
 	}
-	return servicesMap, nil
+
+	return clusterServiceMap{
+		clusterName: nc.name,
+		services:    servicesMap,
+	}, nil
 }
 
 func getIPsOfService(client *internal.ProxmoxClient, ctx context.Context, nodeName string, vmID uint64, isContainer bool) (ips []internal.IP, err error) {
@@ -234,7 +339,12 @@ func getIPsOfService(client *internal.ProxmoxClient, ctx context.Context, nodeNa
 	return filteredIPs, nil
 }
 
-func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName string) (services []internal.Service, err error) {
+func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName string) ([]internal.Service, error) {
+	// Use an explicit local slice instead of a named return value. Yaegi
+	// (Traefik's Go interpreter) can fail to re-initialize named return
+	// variables between calls, causing results to accumulate.
+	services := make([]internal.Service, 0)
+
 	// Scan virtual machines
 	vms, err := client.GetVirtualMachines(ctx, nodeName)
 	if err != nil {
@@ -308,7 +418,7 @@ func scanServices(client *internal.ProxmoxClient, ctx context.Context, nodeName 
 	return services, nil
 }
 
-func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.Configuration {
+func generateConfiguration(clusterMaps []clusterServiceMap, multiEndpoint bool) *dynamic.Configuration {
 	config := &dynamic.Configuration{
 		HTTP: &dynamic.HTTPConfiguration{
 			Routers:           make(map[string]*dynamic.Router),
@@ -330,8 +440,19 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 		},
 	}
 
+	for _, csm := range clusterMaps {
+		addEndpointConfiguration(config, csm, multiEndpoint)
+	}
+
+	return config
+}
+
+// addEndpointConfiguration adds routers and services discovered on a single
+// Proxmox endpoint to the dynamic configuration. Extracted into its own
+// function to guarantee clean variable scoping under yaegi.
+func addEndpointConfiguration(config *dynamic.Configuration, csm clusterServiceMap, multiEndpoint bool) {
 	// Loop through all node service maps
-	for nodeName, services := range servicesMap {
+	for nodeName, services := range csm.services {
 		// Loop through all services in this node
 		for _, service := range services {
 			// Skip disabled services
@@ -359,8 +480,13 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 				}
 			}
 			
-			// Default to service ID if no names found
+			// Default to service ID if no names found. With multiple
+			// endpoints configured, prefix with the endpoint name so equal
+			// VM names/IDs on standalone hosts cannot collide.
 			defaultID := fmt.Sprintf("%s-%d", service.Name, service.ID)
+			if multiEndpoint {
+				defaultID = fmt.Sprintf("%s-%s-%d", csm.clusterName, service.Name, service.ID)
+			}
 			
 			// Convert maps to slices
 			routerNames := mapKeysToSlice(routerPrefixMap)
@@ -421,11 +547,9 @@ func generateConfiguration(servicesMap map[string][]internal.Service) *dynamic.C
 				config.HTTP.Routers[routerName] = router
 			}
 			
-			log.Printf("Created router and service for %s (ID: %d)", service.Name, service.ID)
+			log.Printf("Created router and service for %s (ID: %d) on endpoint %q", service.Name, service.ID, csm.clusterName)
 		}
 	}
-	
-	return config
 }
 
 // Apply router configuration options from labels
@@ -683,6 +807,20 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
+// validateNodeConfig validates a single node configuration entry.
+func validateNodeConfig(nc NodeConfig, label string) error {
+	if nc.ApiEndpoint == "" {
+		return fmt.Errorf("%s: API endpoint must be set", label)
+	}
+	if nc.ApiTokenId == "" {
+		return fmt.Errorf("%s: API token ID must be set", label)
+	}
+	if nc.ApiToken == "" {
+		return fmt.Errorf("%s: API token must be set", label)
+	}
+	return nil
+}
+
 // validateConfig validates the plugin configuration
 func validateConfig(config *Config) error {
 	if config == nil {
@@ -693,6 +831,21 @@ func validateConfig(config *Config) error {
 		return errors.New("poll interval must be set")
 	}
 
+	// Multi-endpoint configuration
+	if len(config.Nodes) > 0 {
+		for i, node := range config.Nodes {
+			label := fmt.Sprintf("nodes[%d]", i)
+			if node.Name != "" {
+				label = fmt.Sprintf("node %q", node.Name)
+			}
+			if err := validateNodeConfig(node, label); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Legacy single-endpoint configuration
 	if config.ApiEndpoint == "" {
 		return errors.New("API endpoint must be set")
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -36,7 +36,9 @@ func TestProviderNew(t *testing.T) {
 				ApiValidateSSL: "true",
 				ApiLogging:     "info",
 			},
-			wantErr: true, // We expect an error because the domain doesn't exist
+			// The endpoint doesn't exist, but an unreachable endpoint is no
+			// longer fatal at startup: it is retried on every poll.
+			wantErr: false,
 		},
 		{
 			name:    "Nil config",

--- a/traefik_proxmox_provider.go
+++ b/traefik_proxmox_provider.go
@@ -8,14 +8,25 @@ import (
 	"github.com/NX211/traefik-proxmox-provider/provider"
 )
 
-// Config the plugin configuration.
-type Config struct {
-	PollInterval   string `json:"pollInterval" yaml:"pollInterval" toml:"pollInterval"`
+// NodeConfig represents the configuration for a single Proxmox endpoint.
+type NodeConfig struct {
+	Name           string `json:"name" yaml:"name" toml:"name"`
 	ApiEndpoint    string `json:"apiEndpoint" yaml:"apiEndpoint" toml:"apiEndpoint"`
 	ApiTokenId     string `json:"apiTokenId" yaml:"apiTokenId" toml:"apiTokenId"`
 	ApiToken       string `json:"apiToken" yaml:"apiToken" toml:"apiToken"`
 	ApiLogging     string `json:"apiLogging" yaml:"apiLogging" toml:"apiLogging"`
 	ApiValidateSSL string `json:"apiValidateSSL" yaml:"apiValidateSSL" toml:"apiValidateSSL"`
+}
+
+// Config the plugin configuration.
+type Config struct {
+	PollInterval   string       `json:"pollInterval" yaml:"pollInterval" toml:"pollInterval"`
+	ApiEndpoint    string       `json:"apiEndpoint" yaml:"apiEndpoint" toml:"apiEndpoint"`
+	ApiTokenId     string       `json:"apiTokenId" yaml:"apiTokenId" toml:"apiTokenId"`
+	ApiToken       string       `json:"apiToken" yaml:"apiToken" toml:"apiToken"`
+	ApiLogging     string       `json:"apiLogging" yaml:"apiLogging" toml:"apiLogging"`
+	ApiValidateSSL string       `json:"apiValidateSSL" yaml:"apiValidateSSL" toml:"apiValidateSSL"`
+	Nodes          []NodeConfig `json:"nodes" yaml:"nodes" toml:"nodes"`
 }
 
 // CreateConfig creates the default plugin configuration.
@@ -38,6 +49,21 @@ type Provider struct {
 
 // New creates a new Provider plugin.
 func New(ctx context.Context, config *Config, name string) (*Provider, error) {
+	// Convert the outer NodeConfig slice to the inner provider.NodeConfig
+	// slice. Use an explicit empty slice rather than a nil var so yaegi
+	// starts from a clean value on every call.
+	innerNodes := make([]provider.NodeConfig, 0, len(config.Nodes))
+	for _, n := range config.Nodes {
+		innerNodes = append(innerNodes, provider.NodeConfig{
+			Name:           n.Name,
+			ApiEndpoint:    n.ApiEndpoint,
+			ApiTokenId:     n.ApiTokenId,
+			ApiToken:       n.ApiToken,
+			ApiLogging:     n.ApiLogging,
+			ApiValidateSSL: n.ApiValidateSSL,
+		})
+	}
+
 	providerConfig := &provider.Config{
 		PollInterval:   config.PollInterval,
 		ApiEndpoint:    config.ApiEndpoint,
@@ -45,6 +71,7 @@ func New(ctx context.Context, config *Config, name string) (*Provider, error) {
 		ApiToken:       config.ApiToken,
 		ApiLogging:     config.ApiLogging,
 		ApiValidateSSL: config.ApiValidateSSL,
+		Nodes:          innerNodes,
 	}
 
 	innerProvider, err := provider.New(ctx, providerConfig, name)


### PR DESCRIPTION
My homelab has two Proxmox nodes that aren't clustered (a PVE 8 box and a smaller PVE 9 one). A standalone node's API only sees itself, so with a single `apiEndpoint` the plugin can never discover both — the workaround is running two plugin instances, which means duplicated config and two providers to keep an eye on.

This adds an optional `nodes` list so one instance can poll several APIs and merge the results into one dynamic configuration:

```yaml
providers:
  plugin:
    traefik-proxmox-provider:
      pollInterval: "30s"
      nodes:
        - name: "pve1"
          apiEndpoint: "https://pve1.example.com:8006"
          apiTokenId: "root@pam!traefik"
          apiToken: "..."
        - name: "pve2"
          apiEndpoint: "https://pve2.example.com:8006"
          apiTokenId: "root@pam!traefik"
          apiToken: "..."
```

Most of this is a port of #43 by @jonmilele: same config shape, the legacy flat config gets wrapped as a single entry, and only auto-generated fallback IDs get the node name prefix (explicit router/service names from labels are left alone). I also kept the yaegi workarounds from that PR — no named return values, logic split into small helpers. #43 was written against an older main and doesn't apply anymore, so this is a rewrite rather than a rebase, but the approach is his.

I changed one thing on purpose: a dead endpoint no longer kills startup. In #43, `logVersion` failing inside `New` takes the whole provider down, and in my case that means "second node powered off → traefik loses the routes of the node that's fine". Now it logs a warning and retries on the next poll; the version line shows up whenever the endpoint first answers. Missing required fields in an entry are still a hard error. And if _all_ endpoints fail during a poll, the provider keeps the last config instead of pushing an empty one.

Flat single-endpoint configs behave exactly as before.

## Testing

`go test ./...` covers the config normalization/validation and the merge/prefix logic. But yaegi accepts a lot less than the compiler does, so I also ran the plugin under a real traefik (3.7.5) as a local plugin, against two fake Proxmox APIs. Both fakes serve a running VM named `web` with vmid 100, which is exactly the collision the prefix is for.

```console
# this assumes all dependencies are installed (traefik, go, etc.)

# fake PVE #1; the second one (:19006) stays down on purpose
$ go run mockpve.go -port 18006 -node pve1 -release 8.4 -vm web -ip 10.0.0.5 &

# plugin source copied to ./plugins-local/src/github.com/NX211/traefik-proxmox-provider
$ traefik --configfile traefik-static.yml &
```

Startup with one endpoint down (traefik prints plugin logs at ERR level, ignore that):

```
17:19:42 Connected to Proxmox VE version 8.4 (endpoint "proxmox")
17:19:42 WARN: Proxmox endpoint "minimox" is unreachable, will retry on next poll: Get "http://127.0.0.1:19006/api2/json/version": dial tcp 127.0.0.1:19006: connect: connection refused
17:19:42 Configuration received config={"http":{"routers":{"proxmox-web-100":{"rule":"Host(`web`)","service":"proxmox-web-100"}},"services":{"proxmox-web-100":{"loadBalancer":{"servers":[{"url":"http://10.0.0.5:80"}]}}}},...}
```

Bring the second one up and the next poll picks it up:

```console
$ go run mockpve.go -port 19006 -node pve2 -release 9.0 -vm web -ip 10.0.1.5 &
```

```
17:20:07 Connected to Proxmox VE version 9.0 (endpoint "minimox")
17:20:07 Configuration received config={"http":{"routers":{"minimox-web-100":{"rule":"Host(`web`)","service":"minimox-web-100"},"proxmox-web-100":{"rule":"Host(`web`)","service":"proxmox-web-100"}},...}
```

No collision, distinct backends:

```console
$ curl -s http://127.0.0.1:18081/api/http/services | ...
minimox-web-100@plugin-traefik-proxmox-provider [{'url': 'http://10.0.1.5:80'}]
proxmox-web-100@plugin-traefik-proxmox-provider [{'url': 'http://10.0.0.5:80'}]
```

Same setup with the old flat config, to check nothing moved — router stays unprefixed:

```
17:20:29 Connected to Proxmox VE version 8.4 (endpoint "default")
17:20:29 Configuration received config={"http":{"routers":{"web-100":{"rule":"Host(`web`)","service":"web-100"}},"services":{"web-100":{"loadBalancer":{"servers":[{"url":"http://10.0.0.5:80"}]}}}},...}
```

<details>
<summary>mockpve.go and traefik-static.yml used above</summary>

```go
// mockpve.go — minimal fake of the PVE API surface the plugin polls
package main

import (
	"flag"
	"fmt"
	"log"
	"net/http"
)

func main() {
	port := flag.Int("port", 18006, "listen port")
	node := flag.String("node", "pve1", "proxmox node name")
	release := flag.String("release", "8.4", "PVE release reported by /version")
	vm := flag.String("vm", "web", "name of the single running VM")
	ip := flag.String("ip", "10.0.0.5", "IP reported by the guest agent")
	flag.Parse()

	writeJSON := func(w http.ResponseWriter, body string) {
		w.Header().Set("Content-Type", "application/json")
		_, _ = fmt.Fprint(w, body)
	}

	mux := http.NewServeMux()
	mux.HandleFunc("/api2/json/version", func(w http.ResponseWriter, r *http.Request) {
		writeJSON(w, fmt.Sprintf(`{"data":{"release":"%s","version":"%s.1"}}`, *release, *release))
	})
	mux.HandleFunc("/api2/json/nodes", func(w http.ResponseWriter, r *http.Request) {
		writeJSON(w, fmt.Sprintf(`{"data":[{"node":"%s","status":"online"}]}`, *node))
	})
	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/qemu", *node), func(w http.ResponseWriter, r *http.Request) {
		writeJSON(w, fmt.Sprintf(`{"data":[{"vmid":100,"name":"%s","status":"running"}]}`, *vm))
	})
	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/lxc", *node), func(w http.ResponseWriter, r *http.Request) {
		writeJSON(w, `{"data":[]}`)
	})
	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/qemu/100/config", *node), func(w http.ResponseWriter, r *http.Request) {
		writeJSON(w, `{"data":{"description":"traefik.enable=true"}}`)
	})
	mux.HandleFunc(fmt.Sprintf("/api2/json/nodes/%s/qemu/100/agent/network-get-interfaces", *node), func(w http.ResponseWriter, r *http.Request) {
		writeJSON(w, fmt.Sprintf(`{"data":{"result":[{"name":"eth0","ip-addresses":[{"ip-address":"%s","ip-address-type":"ipv4","prefix":24}]}]}}`, *ip))
	})

	log.Printf("mock PVE %q (release %s) listening on :%d", *node, *release, *port)
	log.Fatal(http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", *port), mux))
}
```

```yaml
# traefik-static.yml
entryPoints:
  web:
    address: "127.0.0.1:18080"
  traefik:
    address: "127.0.0.1:18081"

api:
  insecure: true

log:
  level: DEBUG

experimental:
  localPlugins:
    traefik-proxmox-provider:
      moduleName: github.com/NX211/traefik-proxmox-provider

providers:
  plugin:
    traefik-proxmox-provider:
      pollInterval: "5s"
      apiLogging: "debug"
      nodes:
        - name: "proxmox"
          apiEndpoint: "http://127.0.0.1:18006"
          apiTokenId: "root@pam!traefik"
          apiToken: "mock-token-1"
          apiValidateSSL: "false"
        - name: "minimox"
          apiEndpoint: "http://127.0.0.1:19006"
          apiTokenId: "root@pam!traefik"
          apiToken: "mock-token-2"
          apiValidateSSL: "false"
```

</details>
